### PR TITLE
Move more parsing in stage2

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         rustflags:
-          - '-C target-cpu=native'
-          - '-C target-cpu=native -C target-feature=-avx2'
+          - "-C target-cpu=native"
+          - "-C target-cpu=native -C target-feature=-avx2"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -40,13 +40,13 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
       - name: run tarpaulin
         env:
-          RUSTFLAGS: '-C target-cpu=native -C target-feature=-avx2'
+          RUSTFLAGS: "-C target-cpu=native -C target-feature=-avx2"
           PROPTEST_CASES: 512
-        run: cargo tarpaulin -v --features no-inline --out Xml -- --test-threads=1 && cp cobertura.xml sse.xml
+        run: cargo tarpaulin -v --features no-inline --out Xml && cp cobertura.xml sse.xml
       - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./sse.xml     
+          file: ./sse.xml
           flags: e
   tarpaulin-avx2:
     runs-on: ubuntu-latest
@@ -62,13 +62,13 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
       - name: run tarpaulin
         env:
-          RUSTFLAGS: '-C target-cpu=native'
+          RUSTFLAGS: "-C target-cpu=native"
           PROPTEST_CASES: 512
-        run: cargo tarpaulin -v --features no-inline --out Xml -- --test-threads=1 && cp cobertura.xml avx.xml
+        run: cargo tarpaulin -v --features no-inline --out Xml && cp cobertura.xml avx.xml
       - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./avx.xml    
+          file: ./avx.xml
           flags: avx2
   tarpaulin-sse-known-key:
     runs-on: ubuntu-latest
@@ -84,13 +84,13 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
       - name: run tarpaulin
         env:
-          RUSTFLAGS: '-C target-cpu=native -C target-feature=-avx2'
+          RUSTFLAGS: "-C target-cpu=native -C target-feature=-avx2"
           PROPTEST_CASES: 512
-        run: cargo tarpaulin -v --features no-inline known-key --out Xml -- --test-threads=1 && cp cobertura.xml sse-known-key.xml
+        run: cargo tarpaulin -v --features no-inline known-key --out Xml && cp cobertura.xml sse-known-key.xml
       - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./sse-known-key.xml     
+          file: ./sse-known-key.xml
           flags: sseKnownKey
   tarpaulin-avx2-known-key:
     runs-on: ubuntu-latest
@@ -106,11 +106,11 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
       - name: run tarpaulin
         env:
-          RUSTFLAGS: '-C target-cpu=native'
+          RUSTFLAGS: "-C target-cpu=native"
           PROPTEST_CASES: 512
-        run: cargo tarpaulin -v --features no-inline known-key --out Xml -- --test-threads=1 && cp cobertura.xml avx2-known-key.xml
+        run: cargo tarpaulin -v --features no-inline known-key --out Xml && cp cobertura.xml avx2-known-key.xml
       - uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./avx2-known-key.xml    
+          file: ./avx2-known-key.xml
           flags: avx2KnownKey

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,21 +49,28 @@ harness = false
 
 [features]
 default = ["swar-number-parsing", "serde_impl"]
-# Support for ARM NEON SIMD
-neon = ["simd-lite"]
+# used for enabeling known keys in favour of a slower
+# hasher that is not protected against hash collision
+# attacks
+known-key = [ "halfbrown/fxhash" ]
 # use 8 number at once parsing strategy
 swar-number-parsing = []
-# serde compatibility
+# serde compatibilitya
 serde_impl = [ "serde", "serde_json", "halfbrown/serde" ]
+# Support for ARM NEON SIMD
+neon = ["simd-lite"]
 # don't inline code - used for debugging
 no-inline = []
+# uses safe slice access ([]) instead of get_unsafe
+# **for debugging**
+safe = []
 # also bench serde in the benchmarks
 bench-serde = []
 # use branch hints - requires nightly :(
 hints = [] # requires nightly
 # for perf testing, used by the example
 perf = ["perfcnt", "getopts", "colored"]
-known-key = [ "halfbrown/fxhash" ]
+
 
 
 [[example]]

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -19,6 +19,7 @@ impl<'de> Deserializer<'de> {
         buffer: &'invoke mut [u8],
         mut idx: usize,
     ) -> Result<&'de str> {
+        use ErrorType::*;
         let input: &mut [u8] = unsafe { std::mem::transmute(input) };
         // Add 1 to skip the initial "
         idx += 1;
@@ -177,20 +178,10 @@ impl<'de> Deserializer<'de> {
                         }) {
                         r
                     } else {
-                        return Err(Self::raw_error(
-                            0,
-                            src_i,
-                            'u',
-                            ErrorType::InvlaidUnicodeCodepoint,
-                        ));
+                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
                     if o == 0 {
-                        return Err(Self::raw_error(
-                            0,
-                            src_i,
-                            'u',
-                            ErrorType::InvlaidUnicodeCodepoint,
-                        ));
+                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
                     // We moved o steps forword at the destiation and 6 on the source
                     src_i += s;
@@ -203,12 +194,7 @@ impl<'de> Deserializer<'de> {
                     let escape_result: u8 =
                         unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
                     if escape_result == 0 {
-                        return Err(Self::raw_error(
-                            0,
-                            src_i,
-                            escape_char as char,
-                            ErrorType::InvalidEscape,
-                        ));
+                        return Err(Self::raw_error(src_i, escape_char as char, InvalidEscape));
                     }
                     unsafe {
                         *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -12,7 +12,7 @@ pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
     // Allow it to keep in sync with upstream
-    #[allow(clippy::if_not_else, mutable_transmutes)]
+    #[allow(clippy::if_not_else, mutable_transmutes, clippy::transmute_ptr_to_ptr)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -12,9 +12,14 @@ pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
     // Allow it to keep in sync with upstream
-    #[allow(clippy::if_not_else)]
+    #[allow(clippy::if_not_else, mutable_transmutes)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_(&mut self, mut idx: usize) -> Result<&'de str> {
+    pub fn parse_str_<'invoke>(
+        input: &'de [u8],
+        buffer: &'invoke mut [u8],
+        mut idx: usize,
+    ) -> Result<&'de str> {
+        let input: &mut [u8] = unsafe { std::mem::transmute(input) };
         // Add 1 to skip the initial "
         idx += 1;
         let mut padding = [0_u8; 32];
@@ -24,8 +29,8 @@ impl<'de> Deserializer<'de> {
         // This is safe since we check sub's lenght in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
-        let src: &[u8] = unsafe { &self.input.get_unchecked(idx..) };
         let mut src_i: usize = 0;
+        let src: &[u8] = unsafe { input.get_unchecked(idx..) };
         let mut len = src_i;
         loop {
             let v: __m256i = if src.len() >= src_i + 32 {
@@ -72,7 +77,7 @@ impl<'de> Deserializer<'de> {
 
                 len += quote_dist as usize;
                 unsafe {
-                    let v = self.input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -94,7 +99,6 @@ impl<'de> Deserializer<'de> {
         }
 
         let mut dst_i: usize = 0;
-        let dst: &mut [u8] = &mut self.strings;
 
         loop {
             let v: __m256i = if src.len() >= src_i + 32 {
@@ -116,7 +120,7 @@ impl<'de> Deserializer<'de> {
 
             #[allow(clippy::cast_ptr_alignment)]
             unsafe {
-                _mm256_storeu_si256(dst.as_mut_ptr().add(dst_i) as *mut __m256i, v)
+                _mm256_storeu_si256(buffer.as_mut_ptr().add(dst_i) as *mut __m256i, v)
             };
 
             // store to dest unconditionally - we can overwrite the bits we don't like
@@ -146,12 +150,11 @@ impl<'de> Deserializer<'de> {
 
                 dst_i += quote_dist as usize;
                 unsafe {
-                    self.input
+                    input
                         .get_unchecked_mut(idx + len..idx + len + dst_i)
-                        .clone_from_slice(&self.strings.get_unchecked(..dst_i));
-                    let v = self.input.get_unchecked(idx..idx + len + dst_i) as *const [u8]
-                        as *const str;
-                    self.str_offset += dst_i as usize;
+                        .clone_from_slice(&buffer.get_unchecked(..dst_i));
+                    let v =
+                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -170,14 +173,24 @@ impl<'de> Deserializer<'de> {
                     dst_i += bs_dist as usize;
                     let (o, s) = if let Ok(r) =
                         handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
-                            dst.get_unchecked_mut(dst_i..)
+                            buffer.get_unchecked_mut(dst_i..)
                         }) {
                         r
                     } else {
-                        return Err(self.error(ErrorType::InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(
+                            0,
+                            src_i,
+                            'u',
+                            ErrorType::InvlaidUnicodeCodepoint,
+                        ));
                     };
                     if o == 0 {
-                        return Err(self.error(ErrorType::InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(
+                            0,
+                            src_i,
+                            'u',
+                            ErrorType::InvlaidUnicodeCodepoint,
+                        ));
                     };
                     // We moved o steps forword at the destiation and 6 on the source
                     src_i += s;
@@ -190,10 +203,15 @@ impl<'de> Deserializer<'de> {
                     let escape_result: u8 =
                         unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
                     if escape_result == 0 {
-                        return Err(self.error(ErrorType::InvalidEscape));
+                        return Err(Self::raw_error(
+                            0,
+                            src_i,
+                            escape_char as char,
+                            ErrorType::InvalidEscape,
+                        ));
                     }
                     unsafe {
-                        *dst.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
+                        *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
                     }
                     src_i += bs_dist as usize + 2;
                     dst_i += bs_dist as usize + 1;

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -14,9 +14,9 @@ impl<'de> Deserializer<'de> {
     // Allow it to keep in sync with upstream
     #[allow(clippy::if_not_else)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_(&mut self) -> Result<&'de str> {
+    pub fn parse_str_(&mut self, mut idx: usize) -> Result<&'de str> {
         // Add 1 to skip the initial "
-        let idx = self.iidx + 1;
+        idx += 1;
         let mut padding = [0_u8; 32];
         //let mut read: usize = 0;
 

--- a/src/avx2/stage1.rs
+++ b/src/avx2/stage1.rs
@@ -400,7 +400,7 @@ impl<'de> Deserializer<'de> {
               __builtin_prefetch(buf + idx + 128);
             #endif
              */
-            let input: SimdInput = fill_input(input.get_unchecked(idx as usize..));
+            let input = fill_input(input.get_unchecked(idx as usize..));
             check_utf8(&input, &mut has_error, &mut previous);
             // detect odd sequences of backslashes
             let odd_ends: u64 =

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,8 +84,6 @@ pub enum ErrorType {
 /// Parser error
 #[derive(Debug, PartialEq)]
 pub struct Error {
-    /// Strucutral the error was encountered at
-    structural: usize,
     /// Byte index it was encountered at
     index: usize,
     /// Current character
@@ -95,9 +93,8 @@ pub struct Error {
 }
 
 impl Error {
-    pub(crate) fn new(structural: usize, index: usize, character: char, error: ErrorType) -> Self {
+    pub(crate) fn new(index: usize, character: char, error: ErrorType) -> Self {
         Self {
-            structural,
             index,
             character,
             error,
@@ -105,7 +102,6 @@ impl Error {
     }
     pub(crate) fn generic(t: ErrorType) -> Self {
         Self {
-            structural: 0,
             index: 0,
             character: '💩', //this is the poop emoji
             error: t,

--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -237,8 +237,8 @@ mod tests {
 
         let mut v = BorrowedValue::from(o);
 
-        assert!(key1.lookup(&BorrowedValue::Null).is_none());
-        assert!(key2.lookup(&BorrowedValue::Null).is_none());
+        assert!(key1.lookup(&BorrowedValue::null()).is_none());
+        assert!(key2.lookup(&BorrowedValue::null()).is_none());
         assert!(key1.lookup(&v).is_some());
         assert!(key2.lookup(&v).is_none());
         assert!(key1.lookup_mut(&mut v).is_some());
@@ -255,7 +255,7 @@ mod tests {
 
         let mut v = BorrowedValue::from(o);
 
-        let mut v1 = BorrowedValue::Null;
+        let mut v1 = BorrowedValue::null();
         assert!(key1.insert(&mut v1, 2.into()).is_err());
         assert!(key2.insert(&mut v1, 2.into()).is_err());
         assert_eq!(key1.insert(&mut v, 2.into()).unwrap(), Some(1.into()));
@@ -274,7 +274,7 @@ mod tests {
 
         let mut v = BorrowedValue::from(o);
 
-        let mut v1 = BorrowedValue::Null;
+        let mut v1 = BorrowedValue::null();
         assert!(key1.lookup_or_insert_mut(&mut v1, || 2.into()).is_err());
         assert!(key2.lookup_or_insert_mut(&mut v1, || 2.into()).is_err());
 
@@ -298,8 +298,8 @@ mod tests {
         o.insert("key".into(), 1.into());
         let v = BorrowedValue::from(o);
 
-        assert!(key1.lookup(&BorrowedValue::Null).is_none());
-        assert!(key2.lookup(&BorrowedValue::Null).is_none());
+        assert!(key1.lookup(&BorrowedValue::null()).is_none());
+        assert!(key2.lookup(&BorrowedValue::null()).is_none());
         assert!(key1.lookup(&v).is_some());
         assert!(key2.lookup(&v).is_none());
     }
@@ -314,7 +314,7 @@ mod tests {
 
         let mut v = BorrowedValue::from(o);
 
-        let mut v1 = BorrowedValue::Null;
+        let mut v1 = BorrowedValue::null();
         assert!(key1.insert(&mut v1, 2.into()).is_err());
         assert!(key2.insert(&mut v1, 2.into()).is_err());
         assert_eq!(key1.insert(&mut v, 2.into()).unwrap(), Some(1.into()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,6 @@ pub use crate::neon::deser::*;
 use crate::neon::stage1::SIMDJSON_PADDING;
 
 mod stage2;
-use stage2::Tape;
 /// simd-json JSON-DOM value
 pub mod value;
 
@@ -162,6 +161,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod known_key;
 #[cfg(feature = "known-key")]
 pub use known_key::{Error as KnownKeyError, KnownKey};
+
+pub use crate::stage2::{StaticTape, Tape};
+/// Parses the json to a tape
+pub fn to_tape<'input>(s: &'input mut [u8]) -> Result<Vec<Tape<'input>>> {
+    let de = stry!(Deserializer::from_slice(s));
+    Ok(de.tape)
+}
 
 pub(crate) struct Deserializer<'de> {
     // Note: we use the 2nd part as both index and lenght since only one is ever

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,11 +179,11 @@ pub(crate) struct Deserializer<'de> {
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn error(&self, error: ErrorType) -> Error {
-        Deserializer::raw_error(self.idx, 0, '?', error)
+        Deserializer::raw_error(0, '?', error)
     }
 
-    fn raw_error(structural: usize, idx: usize, c: char, error: ErrorType) -> Error {
-        Error::new(structural, idx, c, error)
+    fn raw_error(idx: usize, c: char, error: ErrorType) -> Error {
+        Error::new(idx, c, error)
     }
     // By convention, `Deserializer` constructors are named like `from_xyz`.
     // That way basic use cases are satisfied by something like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,13 +254,12 @@ impl<'de> Deserializer<'de> {
     // pull out the check so we don't need to
     // stry every time
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    fn next_(&mut self) -> CharType {
+    fn next_(&mut self) -> (CharType, usize) {
         unsafe {
             self.idx += 1;
             let (c, l, iidx) = self.structural_indexes.get_unchecked(self.idx);
             self.iidx = *iidx as usize;
-            self.len = *l as usize;
-            *c
+            (*c, *l as usize)
         }
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -264,15 +264,15 @@ macro_rules! json_internal {
     //////////////////////////////////////////////////////////////////////////
 
     (null) => {
-        $crate::value::owned::Value::Null
+        $crate::value::owned::Value::Static($crate::StaticNode::Null)
     };
 
     (true) => {
-        $crate::value::owned::Value::Bool(true)
+        $crate::value::owned::Value::Static($crate::StaticNode::Bool(true))
     };
 
     (false) => {
-        $crate::value::owned::Value::Bool(false)
+        $crate::value::owned::Value::Static($crate::StaticNode::Bool(false))
     };
 
     ([]) => {
@@ -415,7 +415,7 @@ mod test {
     #[test]
     fn array() {
         let v: OwnedValue = json!(vec![1]);
-        assert_eq!(OwnedValue::Array(vec![OwnedValue::I64(1)]), v);
+        assert_eq!(OwnedValue::from(vec![1u64]), v);
     }
 
     #[test]

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -6,6 +6,7 @@ use crate::Result;
 use simd_lite::aarch64::*;
 
 impl<'de> Deserializer<'de> {
+    #[allow(clippy::if_not_else, mutable_transmutes)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -7,7 +7,7 @@ use simd_lite::aarch64::*;
 
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_(&mut self, len: usize) -> Result<&'de str> {
+    pub fn parse_str_(&mut self, mut len: usize) -> Result<&'de str> {
         // Add 1 to skip the initial "
         idx += 1;
         let mut padding = [0_u8; 32];

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -6,7 +6,7 @@ use crate::Result;
 use simd_lite::aarch64::*;
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::if_not_else, mutable_transmutes)]
+    #[allow(clippy::if_not_else, mutable_transmutes, clippy::transmute_ptr_to_ptr)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -7,9 +7,9 @@ use simd_lite::aarch64::*;
 
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_(&mut self) -> Result<&'de str> {
+    pub fn parse_str_(&mut self, len: usize) -> Result<&'de str> {
         // Add 1 to skip the initial "
-        let idx = self.iidx + 1;
+        idx += 1;
         let mut padding = [0_u8; 32];
         //let mut read: usize = 0;
 

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -171,7 +171,7 @@ impl<'de> Deserializer<'de> {
                     dst_i += bs_dist as usize;
                     let (o, s) = if let Ok(r) =
                         handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
-                            dst.get_unchecked_mut(dst_i..)
+                            buffer.get_unchecked_mut(dst_i..)
                         }) {
                         r
                     } else {

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -7,7 +7,7 @@ use simd_lite::aarch64::*;
 
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_(&mut self, mut len: usize) -> Result<&'de str> {
+    pub fn parse_str_(&mut self, mut idx: usize) -> Result<&'de str> {
         // Add 1 to skip the initial "
         idx += 1;
         let mut padding = [0_u8; 32];

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -202,7 +202,6 @@ impl<'de> Deserializer<'de> {
                 fraction += u64::from(digit);
             } else {
                 return Err(Self::raw_error(
-                    0,
                     idx + digitcount,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -243,7 +242,6 @@ impl<'de> Deserializer<'de> {
             let d = unsafe { *p.get_unchecked(digitcount) };
             if !is_integer(d) {
                 return Err(Self::raw_error(
-                    0,
                     idx + digitcount,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -274,7 +272,6 @@ impl<'de> Deserializer<'de> {
             if is_integer(d) {
                 // we refuse to parse this
                 return Err(Self::raw_error(
-                    0,
                     idx + digitcount,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -288,7 +285,6 @@ impl<'de> Deserializer<'de> {
             if (exponent > 308) || (exponent < -323) {
                 // we refuse to parse this
                 return Err(Self::raw_error(
-                    0,
                     idx + digitcount,
                     d as char,
                     ErrorType::InvalidExponent,
@@ -300,7 +296,6 @@ impl<'de> Deserializer<'de> {
         let d = unsafe { *p.get_unchecked(digitcount) };
         if is_structural_or_whitespace(d) == 0 {
             Err(Self::raw_error(
-                0,
                 idx + digitcount,
                 d as char,
                 ErrorType::InvalidNumber,
@@ -346,7 +341,6 @@ impl<'de> Deserializer<'de> {
                     i = i1;
                 } else {
                     return Err(Self::raw_error(
-                        0,
                         idx + digitcount,
                         d as char,
                         ErrorType::Overflow,
@@ -360,7 +354,6 @@ impl<'de> Deserializer<'de> {
         if negative && i >= 9_223_372_036_854_775_808 {
             //i64::min_value() * -1
             return Err(Self::raw_error(
-                0,
                 idx + digitcount,
                 d as char,
                 ErrorType::Overflow,
@@ -369,7 +362,6 @@ impl<'de> Deserializer<'de> {
 
         if is_structural_or_whitespace(d) == 0 {
             Err(Self::raw_error(
-                0,
                 idx + digitcount,
                 d as char,
                 ErrorType::InvalidNumber,
@@ -403,7 +395,6 @@ impl<'de> Deserializer<'de> {
             d = unsafe { *buf.get_unchecked(byte_count) };
             if is_not_structural_or_whitespace_or_exponent_or_decimal(d) {
                 return Err(Self::raw_error(
-                    0,
                     idx + byte_count,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -414,7 +405,6 @@ impl<'de> Deserializer<'de> {
             if !is_integer(d) {
                 // must start with an integer
                 return Err(Self::raw_error(
-                    0,
                     idx + byte_count,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -434,7 +424,6 @@ impl<'de> Deserializer<'de> {
                     i = i1;
                 } else {
                     return Err(Self::raw_error(
-                        0,
                         idx + byte_count,
                         d as char,
                         ErrorType::Overflow,
@@ -457,7 +446,6 @@ impl<'de> Deserializer<'de> {
                 i = i.wrapping_mul(10).wrapping_add(u64::from(digit));
             } else {
                 return Err(Self::raw_error(
-                    0,
                     idx + byte_count,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -507,7 +495,6 @@ impl<'de> Deserializer<'de> {
             }
             if !is_integer(d) {
                 return Err(Self::raw_error(
-                    0,
                     idx + byte_count,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -535,7 +522,6 @@ impl<'de> Deserializer<'de> {
             if is_integer(d) {
                 // we refuse to parse this
                 return Err(Self::raw_error(
-                    0,
                     idx + byte_count,
                     d as char,
                     ErrorType::InvalidNumber,
@@ -578,7 +564,6 @@ impl<'de> Deserializer<'de> {
         };
         if is_structural_or_whitespace(d) == 0 {
             return Err(Self::raw_error(
-                0,
                 idx + byte_count,
                 d as char,
                 ErrorType::InvalidNumber,

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -178,7 +178,7 @@ impl<'de> Deserializer<'de> {
         clippy::cast_possible_wrap,
         clippy::cast_precision_loss
     )]
-    fn parse_float(idx: usize, p: &[u8], negative: bool) -> Result<Tape> {
+    fn parse_float(idx: usize, p: &[u8], negative: bool) -> Result<Tape<'static>> {
         let mut digitcount = if negative { 1 } else { 0 };
         let mut i: f64;
         let mut digit: u8;
@@ -326,7 +326,7 @@ impl<'de> Deserializer<'de> {
     ///
     #[inline(never)]
     #[allow(clippy::cast_possible_wrap)]
-    fn parse_large_integer(idx: usize, buf: &[u8], negative: bool) -> Result<Tape> {
+    fn parse_large_integer(idx: usize, buf: &[u8], negative: bool) -> Result<Tape<'static>> {
         let mut digitcount = if negative { 1 } else { 0 };
         let mut i: u64;
         let mut d = unsafe { *buf.get_unchecked(digitcount) };
@@ -396,7 +396,7 @@ impl<'de> Deserializer<'de> {
         clippy::cast_precision_loss,
         clippy::cast_possible_wrap
     )]
-    pub fn parse_number_int(idx: usize, buf: &[u8], negative: bool) -> Result<Tape> {
+    pub fn parse_number_int(idx: usize, buf: &[u8], negative: bool) -> Result<Tape<'static>> {
         let mut byte_count = if negative { 1 } else { 0 };
         let mut ignore_count: u8 = 0;
         //let startdigits: *const u8 = p;

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -176,6 +176,7 @@ impl<'de> Deserializer<'de> {
         let mut digitcount = if negative { 1 } else { 0 };
         let mut i: f64;
         let mut digit: u8;
+        let mut d;
         if unsafe { *p.get_unchecked(digitcount) } == b'0' {
             // 0 cannot be followed by an integer
             digitcount += 1;
@@ -195,7 +196,7 @@ impl<'de> Deserializer<'de> {
             let mut fraction_weight: u64 = 10;
             digitcount += 1;
             //let mut fractionalweight: f64 = 1.0;
-            let d = unsafe { *p.get_unchecked(digitcount) };
+            d = unsafe { *p.get_unchecked(digitcount) };
             if is_integer(d) {
                 digit = d - b'0';
                 digitcount += 1;
@@ -239,7 +240,7 @@ impl<'de> Deserializer<'de> {
             } else if unsafe { *p.get_unchecked(digitcount) } == b'+' {
                 digitcount += 1;
             }
-            let d = unsafe { *p.get_unchecked(digitcount) };
+            d = unsafe { *p.get_unchecked(digitcount) };
             if !is_integer(d) {
                 return Err(Self::raw_error(
                     idx + digitcount,
@@ -250,25 +251,25 @@ impl<'de> Deserializer<'de> {
             digit = unsafe { *p.get_unchecked(digitcount) } - b'0';
             let mut expnumber: u32 = u32::from(digit); // exponential part
             digitcount += 1;
-            let d = unsafe { *p.get_unchecked(digitcount) };
+            d = unsafe { *p.get_unchecked(digitcount) };
             if is_integer(d) {
                 digit = d - b'0';
                 expnumber = 10 * expnumber + u32::from(digit);
                 digitcount += 1;
             }
-            let d = unsafe { *p.get_unchecked(digitcount) };
+            d = unsafe { *p.get_unchecked(digitcount) };
             if is_integer(d) {
                 digit = d - b'0';
                 expnumber = 10 * expnumber + u32::from(digit);
                 digitcount += 1;
             }
-            let d = unsafe { *p.get_unchecked(digitcount) };
+            d = unsafe { *p.get_unchecked(digitcount) };
             if is_integer(d) {
                 digit = d - b'0';
                 expnumber = 10 * expnumber + u32::from(digit);
                 digitcount += 1;
             }
-            let d = unsafe { *p.get_unchecked(digitcount) };
+            d = unsafe { *p.get_unchecked(digitcount) };
             if is_integer(d) {
                 // we refuse to parse this
                 return Err(Self::raw_error(
@@ -293,7 +294,7 @@ impl<'de> Deserializer<'de> {
             i *= POWER_OF_TEN[(323 + exponent) as usize];
         }
 
-        let d = unsafe { *p.get_unchecked(digitcount) };
+        d = unsafe { *p.get_unchecked(digitcount) };
         if is_structural_or_whitespace(d) == 0 {
             Err(Self::raw_error(
                 idx + digitcount,
@@ -563,11 +564,11 @@ impl<'de> Deserializer<'de> {
             }
         };
         if is_structural_or_whitespace(d) == 0 {
-            return Err(Self::raw_error(
+            Err(Self::raw_error(
                 idx + byte_count,
                 d as char,
                 ErrorType::InvalidNumber,
-            ));
+            ))
         } else {
             Ok(v)
         }

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -592,6 +592,31 @@ mod test {
         let mut too_small = unsafe { too_small.as_bytes_mut() };
         let v_too_small = to_value(&mut too_small);
         assert!(v_too_small.is_err());
+        let mut too_big = String::from("1e1000");
+        let mut too_big = unsafe { too_big.as_bytes_mut() };
+        let v_too_big = to_value(&mut too_big);
+        assert!(v_too_big.is_err());
+        let mut too_small = String::from("1e-1000");
+        let mut too_small = unsafe { too_small.as_bytes_mut() };
+        let v_too_small = to_value(&mut too_small);
+        assert!(v_too_small.is_err());
+
+        let mut too_big = String::from("100000000000000000000000000000000000000000000e309");
+        let mut too_big = unsafe { too_big.as_bytes_mut() };
+        let v_too_big = to_value(&mut too_big);
+        assert!(v_too_big.is_err());
+        let mut too_small = String::from("100000000000000000000000000000000000000000000e-324");
+        let mut too_small = unsafe { too_small.as_bytes_mut() };
+        let v_too_small = to_value(&mut too_small);
+        assert!(v_too_small.is_err());
+        let mut too_big = String::from("100000000000000000000000000000000000000000000e1000");
+        let mut too_big = unsafe { too_big.as_bytes_mut() };
+        let v_too_big = to_value(&mut too_big);
+        assert!(v_too_big.is_err());
+        let mut too_small = String::from("100000000000000000000000000000000000000000000e-1000");
+        let mut too_small = unsafe { too_small.as_bytes_mut() };
+        let v_too_small = to_value(&mut too_small);
+        assert!(v_too_small.is_err());
     }
 
     #[test]
@@ -601,6 +626,34 @@ mod test {
         let r = to_value(&mut i);
         assert!(r.is_err());
         let mut i = String::from("1.e");
+        let mut i = unsafe { i.as_bytes_mut() };
+        let r = to_value(&mut i);
+        assert!(r.is_err());
+        let mut i = String::from("100000000000000000000000000000000000000000000.");
+        let mut i = unsafe { i.as_bytes_mut() };
+        let r = to_value(&mut i);
+        assert!(r.is_err());
+        let mut i = String::from("100000000000000000000000000000000000000000000.e");
+        let mut i = unsafe { i.as_bytes_mut() };
+        let r = to_value(&mut i);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn bad_e() {
+        let mut i = String::from("1.0e");
+        let mut i = unsafe { i.as_bytes_mut() };
+        let r = to_value(&mut i);
+        assert!(r.is_err());
+        let mut i = String::from("1.0e");
+        let mut i = unsafe { i.as_bytes_mut() };
+        let r = to_value(&mut i);
+        assert!(r.is_err());
+        let mut i = String::from("100000000000000000000000000000000000000000000.0e");
+        let mut i = unsafe { i.as_bytes_mut() };
+        let r = to_value(&mut i);
+        assert!(r.is_err());
+        let mut i = String::from("100000000000000000000000000000000000000000000.0ee");
         let mut i = unsafe { i.as_bytes_mut() };
         let r = to_value(&mut i);
         assert!(r.is_err());

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -81,9 +81,9 @@ impl serde_ext::ser::Error for Error {
 // Functions purely used by serde
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    fn next(&mut self) -> Result<Tape> {
+    fn next(&mut self) -> Result<Tape<'de>> {
         self.idx += 1;
-        self.structural_indexes
+        self.tape
             .get(self.idx)
             .copied()
             .ok_or_else(|| self.error(ErrorType::Syntax))
@@ -91,7 +91,7 @@ impl<'de> Deserializer<'de> {
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn peek(&self) -> Result<Tape> {
-        self.structural_indexes
+        self.tape
             .get(self.idx + 1)
             .copied()
             .ok_or_else(|| self.error(ErrorType::UnexpectedEnd))

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -101,11 +101,7 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_signed(&mut self) -> Result<i64> {
         match self.next_() {
-            (CharType::NegNum, idx) => match stry!(self.parse_number(idx as usize, true)) {
-                Number::I64(n) => Ok(n),
-                _ => Err(self.error(ErrorType::ExpectedSigned)),
-            },
-            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
+            (CharType::Number(neg), idx) => match stry!(self.parse_number(idx as usize, neg)) {
                 Number::I64(n) => Ok(n),
                 Number::U64(n) => n
                     .try_into()
@@ -120,7 +116,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_sign_loss)]
     fn parse_unsigned(&mut self) -> Result<u64> {
         match self.next_() {
-            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
+            (CharType::Number(false), idx) => match stry!(self.parse_number(idx as usize, false)) {
                 Number::U64(n) => Ok(n as u64),
                 _ => Err(self.error(ErrorType::ExpectedUnsigned)),
             },
@@ -131,12 +127,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
         match self.next_() {
-            (CharType::NegNum, idx) => match stry!(self.parse_number(idx as usize, true)) {
-                Number::F64(n) => Ok(n),
-                Number::I64(n) => Ok(n as f64),
-                Number::U64(n) => Ok(n as f64),
-            },
-            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
+            (CharType::Number(neg), idx) => match stry!(self.parse_number(idx as usize, neg)) {
                 Number::F64(n) => Ok(n),
                 Number::I64(n) => Ok(n as f64),
                 Number::U64(n) => Ok(n as f64),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -86,7 +86,7 @@ impl<'de> Deserializer<'de> {
         self.idx += 1;
         self.structural_indexes
             .get(self.idx)
-            .map(|v| *v)
+            .copied()
             .ok_or_else(|| self.error(ErrorType::Syntax))
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -92,11 +92,10 @@ impl<'de> Deserializer<'de> {
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn peek(&self) -> Result<CharType> {
-        if let Some((c, _)) = self.structural_indexes.get(self.idx + 1) {
-            Ok(*c)
-        } else {
-            Err(self.error(ErrorType::UnexpectedEnd))
-        }
+        self.structural_indexes
+            .get(self.idx + 1)
+            .map(|v| v.0)
+            .ok_or_else(|| self.error(ErrorType::UnexpectedEnd))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
@@ -122,7 +121,6 @@ impl<'de> Deserializer<'de> {
     fn parse_unsigned(&mut self) -> Result<u64> {
         match self.next_() {
             (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
-                Number::I64(n) => Ok(n as u64),
                 Number::U64(n) => Ok(n as u64),
                 _ => Err(self.error(ErrorType::ExpectedUnsigned)),
             },

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -101,7 +101,11 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_signed(&mut self) -> Result<i64> {
         match self.next_() {
-            (CharType::Number(neg), idx) => match stry!(self.parse_number(idx as usize, neg)) {
+            (CharType::NegNum, idx) => match stry!(self.parse_number(idx as usize, true)) {
+                Number::I64(n) => Ok(n),
+                _ => Err(self.error(ErrorType::ExpectedSigned)),
+            },
+            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
                 Number::I64(n) => Ok(n),
                 Number::U64(n) => n
                     .try_into()
@@ -116,7 +120,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_sign_loss)]
     fn parse_unsigned(&mut self) -> Result<u64> {
         match self.next_() {
-            (CharType::Number(false), idx) => match stry!(self.parse_number(idx as usize, false)) {
+            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
                 Number::U64(n) => Ok(n as u64),
                 _ => Err(self.error(ErrorType::ExpectedUnsigned)),
             },
@@ -127,7 +131,12 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
         match self.next_() {
-            (CharType::Number(neg), idx) => match stry!(self.parse_number(idx as usize, neg)) {
+            (CharType::NegNum, idx) => match stry!(self.parse_number(idx as usize, true)) {
+                Number::F64(n) => Ok(n),
+                Number::I64(n) => Ok(n as f64),
+                Number::U64(n) => Ok(n as f64),
+            },
+            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
                 Number::F64(n) => Ok(n),
                 Number::I64(n) => Ok(n as f64),
                 Number::U64(n) => Ok(n as f64),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -50,7 +50,6 @@ where
     T: Deserialize<'a>,
 {
     let mut deserializer = stry!(Deserializer::from_slice(s));
-    dbg!(&deserializer.structural_indexes);
     T::deserialize(&mut deserializer)
 }
 /// parses a str  using a serde deserializer.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -105,11 +105,11 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_signed(&mut self) -> Result<i64> {
         match self.next_() {
-            CharType::NegNum => match stry!(self.parse_number(true)) {
+            (CharType::NegNum, _) => match stry!(self.parse_number(true)) {
                 Number::I64(n) => Ok(n),
                 _ => Err(self.error(ErrorType::ExpectedSigned)),
             },
-            CharType::PosNum => match stry!(self.parse_number(false)) {
+            (CharType::PosNum, _) => match stry!(self.parse_number(false)) {
                 Number::I64(n) => Ok(n),
                 Number::U64(n) => n
                     .try_into()
@@ -124,7 +124,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_sign_loss)]
     fn parse_unsigned(&mut self) -> Result<u64> {
         match self.next_() {
-            CharType::PosNum => match stry!(self.parse_number(false)) {
+            (CharType::PosNum, _) => match stry!(self.parse_number(false)) {
                 Number::I64(n) => Ok(n as u64),
                 Number::U64(n) => Ok(n as u64),
                 _ => Err(self.error(ErrorType::ExpectedUnsigned)),
@@ -136,12 +136,12 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
         match self.next_() {
-            CharType::NegNum => match stry!(self.parse_number(true)) {
+            (CharType::NegNum, _) => match stry!(self.parse_number(true)) {
                 Number::F64(n) => Ok(n),
                 Number::I64(n) => Ok(n as f64),
                 Number::U64(n) => Ok(n as f64),
             },
-            CharType::PosNum => match stry!(self.parse_number(false)) {
+            (CharType::PosNum, _) => match stry!(self.parse_number(false)) {
                 Number::F64(n) => Ok(n),
                 Number::I64(n) => Ok(n as f64),
                 Number::U64(n) => Ok(n as f64),

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -15,8 +15,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        match dbg!(stry!(self.next())) {
-            CharType::String => visitor.visit_borrowed_str(dbg!(stry!(self.parse_str_()))),
+        match stry!(self.next()) {
+            CharType::String => visitor.visit_borrowed_str(stry!(self.parse_str_())),
             CharType::Null => visitor.visit_unit(),
             CharType::True => visitor.visit_bool(true),
             CharType::False => visitor.visit_bool(false),
@@ -68,10 +68,10 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if dbg!(stry!(self.next())) != CharType::String {
+        if stry!(self.next()) != CharType::String {
             return Err(self.error(ErrorType::ExpectedString));
         }
-        visitor.visit_borrowed_str(dbg!(stry!(self.parse_str_())))
+        visitor.visit_borrowed_str(stry!(self.parse_str_()))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -370,7 +370,6 @@ impl<'de, 'a> MapAccess<'de> for CommaSeparated<'a, 'de> {
             Ok(None)
         } else {
             self.len -= 1;
-            dbg!("key");
             seed.deserialize(&mut *self.de).map(Some)
         }
     }
@@ -381,7 +380,6 @@ impl<'de, 'a> MapAccess<'de> for CommaSeparated<'a, 'de> {
         V: DeserializeSeed<'de>,
     {
         // read the value
-        dbg!("value");
         seed.deserialize(&mut *self.de)
     }
 

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -22,12 +22,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             (CharType::Null, _) => visitor.visit_unit(),
             (CharType::True, _) => visitor.visit_bool(true),
             (CharType::False, _) => visitor.visit_bool(false),
-            (CharType::NegNum, idx) => match stry!(self.parse_number(idx as usize, true)) {
-                Number::F64(n) => visitor.visit_f64(n),
-                Number::I64(n) => visitor.visit_i64(n),
-                Number::U64(n) => visitor.visit_u64(n),
-            },
-            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
+            (CharType::Number(neg), idx) => match stry!(self.parse_number(idx as usize, neg)) {
                 Number::F64(n) => visitor.visit_f64(n),
                 Number::I64(n) => visitor.visit_i64(n),
                 Number::U64(n) => visitor.visit_u64(n),

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -22,7 +22,12 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             (CharType::Null, _) => visitor.visit_unit(),
             (CharType::True, _) => visitor.visit_bool(true),
             (CharType::False, _) => visitor.visit_bool(false),
-            (CharType::Number(neg), idx) => match stry!(self.parse_number(idx as usize, neg)) {
+            (CharType::NegNum, idx) => match stry!(self.parse_number(idx as usize, true)) {
+                Number::F64(n) => visitor.visit_f64(n),
+                Number::I64(n) => visitor.visit_i64(n),
+                Number::U64(n) => visitor.visit_u64(n),
+            },
+            (CharType::PosNum, idx) => match stry!(self.parse_number(idx as usize, false)) {
                 Number::F64(n) => visitor.visit_f64(n),
                 Number::I64(n) => visitor.visit_i64(n),
                 Number::U64(n) => visitor.visit_u64(n),

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,4 +1,3 @@
-use crate::stage2::{StaticTape, Tape};
 use crate::*;
 use serde_ext::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde_ext::forward_to_deserialize_any;
@@ -18,14 +17,14 @@ where
         V: Visitor<'de>,
     {
         match stry!(self.next()) {
-            Tape::String(s) => visitor.visit_borrowed_str(s),
-            Tape::Static(StaticTape::Null) => visitor.visit_unit(),
-            Tape::Static(StaticTape::Bool(b)) => visitor.visit_bool(b),
-            Tape::Static(StaticTape::F64(n)) => visitor.visit_f64(n),
-            Tape::Static(StaticTape::I64(n)) => visitor.visit_i64(n),
-            Tape::Static(StaticTape::U64(n)) => visitor.visit_u64(n),
-            Tape::Array(len) => visitor.visit_seq(CommaSeparated::new(&mut self, len as usize)),
-            Tape::Object(len) => visitor.visit_map(CommaSeparated::new(&mut self, len as usize)),
+            Node::String(s) => visitor.visit_borrowed_str(s),
+            Node::Static(StaticNode::Null) => visitor.visit_unit(),
+            Node::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
+            Node::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
+            Node::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
+            Node::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
+            Node::Array(len) => visitor.visit_seq(CommaSeparated::new(&mut self, len as usize)),
+            Node::Object(len) => visitor.visit_map(CommaSeparated::new(&mut self, len as usize)),
         }
     }
 
@@ -49,7 +48,7 @@ where
         V: Visitor<'de>,
     {
         match stry!(self.next()) {
-            Tape::Static(StaticTape::Bool(b)) => visitor.visit_bool(b),
+            Node::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
             _c => Err(self.error(ErrorType::ExpectedBoolean)),
         }
     }
@@ -61,7 +60,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if let Ok(Tape::String(s)) = self.next() {
+        if let Ok(Node::String(s)) = self.next() {
             visitor.visit_borrowed_str(s)
         } else {
             Err(self.error(ErrorType::ExpectedString))
@@ -73,7 +72,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if let Ok(Tape::String(s)) = self.next() {
+        if let Ok(Node::String(s)) = self.next() {
             visitor.visit_str(s)
         } else {
             Err(self.error(ErrorType::ExpectedString))
@@ -190,7 +189,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if stry!(self.peek()) == Tape::Static(StaticTape::Null) {
+        if stry!(self.peek()) == Node::Static(StaticNode::Null) {
             self.skip();
             visitor.visit_unit()
         } else {
@@ -204,7 +203,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if stry!(self.next()) != Tape::Static(StaticTape::Null) {
+        if stry!(self.next()) != Node::Static(StaticNode::Null) {
             return Err(self.error(ErrorType::ExpectedNull));
         }
         visitor.visit_unit()
@@ -219,7 +218,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Tape::Array(len)) = self.next() {
+        if let Ok(Node::Array(len)) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_seq(CommaSeparated::new(&mut self, len as usize))
         } else {
@@ -282,7 +281,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Tape::Object(len)) = self.next() {
+        if let Ok(Node::Object(len)) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_map(CommaSeparated::new(&mut self, len as usize))
         } else {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -244,10 +244,10 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let r = self.deserialize_seq(visitor);
+        self.deserialize_seq(visitor)
         // tuples have a known length damn you serde ...
         //self.skip();
-        r
+        // r
     }
 
     // Tuple structs look just like sequences in JSON.

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -3,7 +3,10 @@ use crate::*;
 use serde_ext::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde_ext::forward_to_deserialize_any;
 
-impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de>
+where
+    'de: 'a,
+{
     type Error = Error;
 
     // Look at the input data to decide what Serde data model type to
@@ -15,7 +18,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         match stry!(self.next()) {
-            Tape::String(idx) => visitor.visit_borrowed_str(stry!(self.parse_str_(idx as usize))),
+            Tape::String(s) => visitor.visit_borrowed_str(s),
             Tape::Null => visitor.visit_unit(),
             Tape::True => visitor.visit_bool(true),
             Tape::False => visitor.visit_bool(false),
@@ -60,8 +63,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if let Ok(Tape::String(idx)) = self.next() {
-            visitor.visit_borrowed_str(stry!(self.parse_str_(idx as usize)))
+        if let Ok(Tape::String(s)) = self.next() {
+            visitor.visit_borrowed_str(s)
         } else {
             Err(self.error(ErrorType::ExpectedString))
         }
@@ -72,8 +75,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        if let Ok(Tape::String(idx)) = self.next() {
-            visitor.visit_str(stry!(self.parse_str_(idx as usize)))
+        if let Ok(Tape::String(s)) = self.next() {
+            visitor.visit_str(s)
         } else {
             Err(self.error(ErrorType::ExpectedString))
         }

--- a/src/serde/value/borrowed/de.rs
+++ b/src/serde/value/borrowed/de.rs
@@ -1,3 +1,4 @@
+use crate::stage2::StaticTape;
 use crate::value::borrowed::{Object, Value};
 use crate::Error;
 use serde_ext::de::{
@@ -18,11 +19,11 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         V: Visitor<'de>,
     {
         match self {
-            Value::Null => visitor.visit_unit(),
-            Value::Bool(b) => visitor.visit_bool(b),
-            Value::I64(n) => visitor.visit_i64(n),
-            Value::U64(n) => visitor.visit_u64(n),
-            Value::F64(n) => visitor.visit_f64(n),
+            Value::Static(StaticTape::Null) => visitor.visit_unit(),
+            Value::Static(StaticTape::Bool(b)) => visitor.visit_bool(b),
+            Value::Static(StaticTape::I64(n)) => visitor.visit_i64(n),
+            Value::Static(StaticTape::U64(n)) => visitor.visit_u64(n),
+            Value::Static(StaticTape::F64(n)) => visitor.visit_f64(n),
             Value::String(s) => match s {
                 Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
                 Cow::Owned(s) => visitor.visit_string(s),
@@ -30,7 +31,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
             Value::Array(a) => visitor.visit_seq(Array(a.iter())),
             Value::Object(o) => visitor.visit_map(ObjectAccess {
                 i: o.iter(),
-                v: &Value::Null,
+                v: &Value::Static(StaticTape::Null),
             }),
         }
     }
@@ -113,19 +114,19 @@ impl<'de> Visitor<'de> for ValueVisitor {
     /****************** unit ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Null)
+        Ok(Value::Static(StaticTape::Null))
     }
 
     /****************** bool ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(Value::Bool(value))
+        Ok(Value::Static(StaticTape::Bool(value)))
     }
 
     /****************** Option ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Null)
+        Ok(Value::Static(StaticTape::Null))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -150,7 +151,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(i64::from(value)))
+        Ok(Value::Static(StaticTape::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -158,7 +159,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(i64::from(value)))
+        Ok(Value::Static(StaticTape::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -166,7 +167,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(i64::from(value)))
+        Ok(Value::Static(StaticTape::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -174,7 +175,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(value))
+        Ok(Value::Static(StaticTape::I64(value)))
     }
 
     /****************** u64 ******************/
@@ -184,7 +185,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(u64::from(value)))
+        Ok(Value::Static(StaticTape::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -192,7 +193,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(u64::from(value)))
+        Ok(Value::Static(StaticTape::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -200,7 +201,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(u64::from(value)))
+        Ok(Value::Static(StaticTape::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -208,7 +209,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(value))
+        Ok(Value::Static(StaticTape::U64(value)))
     }
 
     /****************** f64 ******************/
@@ -218,7 +219,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::F64(f64::from(value)))
+        Ok(Value::Static(StaticTape::F64(f64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -226,7 +227,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::F64(value))
+        Ok(Value::Static(StaticTape::F64(value)))
     }
 
     /****************** stringy stuff ******************/

--- a/src/serde/value/borrowed/de.rs
+++ b/src/serde/value/borrowed/de.rs
@@ -1,6 +1,6 @@
-use crate::stage2::StaticTape;
 use crate::value::borrowed::{Object, Value};
 use crate::Error;
+use crate::StaticNode;
 use serde_ext::de::{
     self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor,
 };
@@ -19,11 +19,11 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         V: Visitor<'de>,
     {
         match self {
-            Value::Static(StaticTape::Null) => visitor.visit_unit(),
-            Value::Static(StaticTape::Bool(b)) => visitor.visit_bool(b),
-            Value::Static(StaticTape::I64(n)) => visitor.visit_i64(n),
-            Value::Static(StaticTape::U64(n)) => visitor.visit_u64(n),
-            Value::Static(StaticTape::F64(n)) => visitor.visit_f64(n),
+            Value::Static(StaticNode::Null) => visitor.visit_unit(),
+            Value::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
+            Value::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
+            Value::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
+            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
             Value::String(s) => match s {
                 Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
                 Cow::Owned(s) => visitor.visit_string(s),
@@ -31,7 +31,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
             Value::Array(a) => visitor.visit_seq(Array(a.iter())),
             Value::Object(o) => visitor.visit_map(ObjectAccess {
                 i: o.iter(),
-                v: &Value::Static(StaticTape::Null),
+                v: &Value::Static(StaticNode::Null),
             }),
         }
     }
@@ -114,19 +114,19 @@ impl<'de> Visitor<'de> for ValueVisitor {
     /****************** unit ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticTape::Null))
+        Ok(Value::Static(StaticNode::Null))
     }
 
     /****************** bool ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticTape::Bool(value)))
+        Ok(Value::Static(StaticNode::Bool(value)))
     }
 
     /****************** Option ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticTape::Null))
+        Ok(Value::Static(StaticNode::Null))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -151,7 +151,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::I64(i64::from(value))))
+        Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -159,7 +159,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::I64(i64::from(value))))
+        Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -167,7 +167,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::I64(i64::from(value))))
+        Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -175,7 +175,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::I64(value)))
+        Ok(Value::Static(StaticNode::I64(value)))
     }
 
     /****************** u64 ******************/
@@ -185,7 +185,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::U64(u64::from(value))))
+        Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -193,7 +193,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::U64(u64::from(value))))
+        Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -201,7 +201,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::U64(u64::from(value))))
+        Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -209,7 +209,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::U64(value)))
+        Ok(Value::Static(StaticNode::U64(value)))
     }
 
     /****************** f64 ******************/
@@ -219,7 +219,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::F64(f64::from(value))))
+        Ok(Value::Static(StaticNode::F64(f64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -227,7 +227,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticTape::F64(value)))
+        Ok(Value::Static(StaticNode::F64(value)))
     }
 
     /****************** stringy stuff ******************/

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -1,3 +1,4 @@
+use crate::stage2::StaticTape;
 use crate::value::borrowed::Value;
 use serde_ext::ser::{
     self, Serialize, SerializeMap as SerializeMapTrait, SerializeSeq as SerializeSeqTrait,
@@ -10,11 +11,11 @@ impl<'a> Serialize for Value<'a> {
         S: ser::Serializer,
     {
         match self {
-            Value::Bool(b) => serializer.serialize_bool(*b),
-            Value::Null => serializer.serialize_unit(),
-            Value::F64(f) => serializer.serialize_f64(*f),
-            Value::I64(i) => serializer.serialize_i64(*i),
-            Value::U64(i) => serializer.serialize_u64(*i),
+            Value::Static(StaticTape::Null) => serializer.serialize_unit(),
+            Value::Static(StaticTape::Bool(b)) => serializer.serialize_bool(*b),
+            Value::Static(StaticTape::F64(f)) => serializer.serialize_f64(*f),
+            Value::Static(StaticTape::I64(i)) => serializer.serialize_i64(*i),
+            Value::Static(StaticTape::U64(i)) => serializer.serialize_u64(*i),
             Value::String(Cow::Borrowed(s)) => serializer.serialize_str(s),
             Value::String(Cow::Owned(s)) => serializer.serialize_str(&s),
             Value::Array(v) => {

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -1,5 +1,5 @@
-use crate::stage2::StaticTape;
 use crate::value::borrowed::Value;
+use crate::StaticNode;
 use serde_ext::ser::{
     self, Serialize, SerializeMap as SerializeMapTrait, SerializeSeq as SerializeSeqTrait,
 };
@@ -11,11 +11,11 @@ impl<'a> Serialize for Value<'a> {
         S: ser::Serializer,
     {
         match self {
-            Value::Static(StaticTape::Null) => serializer.serialize_unit(),
-            Value::Static(StaticTape::Bool(b)) => serializer.serialize_bool(*b),
-            Value::Static(StaticTape::F64(f)) => serializer.serialize_f64(*f),
-            Value::Static(StaticTape::I64(i)) => serializer.serialize_i64(*i),
-            Value::Static(StaticTape::U64(i)) => serializer.serialize_u64(*i),
+            Value::Static(StaticNode::Null) => serializer.serialize_unit(),
+            Value::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
+            Value::Static(StaticNode::F64(f)) => serializer.serialize_f64(*f),
+            Value::Static(StaticNode::I64(i)) => serializer.serialize_i64(*i),
+            Value::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
             Value::String(Cow::Borrowed(s)) => serializer.serialize_str(s),
             Value::String(Cow::Owned(s)) => serializer.serialize_str(&s),
             Value::Array(v) => {

--- a/src/serde/value/owned/de.rs
+++ b/src/serde/value/owned/de.rs
@@ -1,4 +1,5 @@
 use crate::value::owned::{Object, Value};
+use crate::StaticNode;
 use crate::{stry, Error};
 use serde::de::{
     self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Unexpected, Visitor,
@@ -19,11 +20,11 @@ impl<'de> de::Deserializer<'de> for Value {
         V: Visitor<'de>,
     {
         match self {
-            Self::Null => visitor.visit_unit(),
-            Self::Bool(b) => visitor.visit_bool(b),
-            Self::I64(n) => visitor.visit_i64(n),
-            Self::U64(n) => visitor.visit_u64(n),
-            Self::F64(n) => visitor.visit_f64(n),
+            Self::Static(StaticNode::Null) => visitor.visit_unit(),
+            Self::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
+            Self::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
+            Self::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
+            Self::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
             Self::String(s) => visitor.visit_string(s),
             Self::Array(a) => visit_array(a, visitor),
             Self::Object(o) => visit_object(o, visitor),
@@ -405,19 +406,19 @@ impl<'de> Visitor<'de> for ValueVisitor {
     /****************** unit ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Null)
+        Ok(Value::Static(StaticNode::Null))
     }
 
     /****************** bool ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(Value::Bool(value))
+        Ok(Value::Static(StaticNode::Bool(value)))
     }
 
     /****************** Option ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Null)
+        Ok(Value::Static(StaticNode::Null))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -442,7 +443,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(i64::from(value)))
+        Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -450,7 +451,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(i64::from(value)))
+        Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -458,7 +459,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(i64::from(value)))
+        Ok(Value::Static(StaticNode::I64(i64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -466,7 +467,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::I64(value))
+        Ok(Value::Static(StaticNode::I64(value)))
     }
 
     /****************** u64 ******************/
@@ -476,7 +477,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(u64::from(value)))
+        Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -484,7 +485,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(u64::from(value)))
+        Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -492,7 +493,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(u64::from(value)))
+        Ok(Value::Static(StaticNode::U64(u64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -500,7 +501,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::U64(value))
+        Ok(Value::Static(StaticNode::U64(value)))
     }
 
     /****************** f64 ******************/
@@ -510,7 +511,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::F64(f64::from(value)))
+        Ok(Value::Static(StaticNode::F64(f64::from(value))))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -518,7 +519,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::F64(value))
+        Ok(Value::Static(StaticNode::F64(value)))
     }
 
     /****************** stringy stuff ******************/

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -1,6 +1,6 @@
 use super::to_value;
 use crate::value::owned::{Object, Value};
-use crate::{stry, Error, ErrorType, Result};
+use crate::{stry, Error, ErrorType, Result, StaticNode};
 use serde::ser::{self, Serialize};
 use serde_ext::ser::{SerializeMap as SerializeMapTrait, SerializeSeq as SerializeSeqTrait};
 
@@ -12,11 +12,11 @@ impl Serialize for Value {
         S: ser::Serializer,
     {
         match self {
-            Self::Bool(b) => serializer.serialize_bool(*b),
-            Self::Null => serializer.serialize_unit(),
-            Self::F64(f) => serializer.serialize_f64(*f),
-            Self::I64(i) => serializer.serialize_i64(*i),
-            Self::U64(i) => serializer.serialize_u64(*i),
+            Self::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
+            Self::Static(StaticNode::Null) => serializer.serialize_unit(),
+            Self::Static(StaticNode::F64(f)) => serializer.serialize_f64(*f),
+            Self::Static(StaticNode::I64(i)) => serializer.serialize_i64(*i),
+            Self::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
             Self::String(s) => serializer.serialize_str(&s),
             Self::Array(v) => {
                 let mut seq = serializer.serialize_seq(Some(v.len()))?;
@@ -57,7 +57,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_bool(self, value: bool) -> Result<Value> {
-        Ok(Value::Bool(value))
+        Ok(Value::Static(StaticNode::Bool(value)))
     }
 
     #[inline]
@@ -76,7 +76,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_i64(self, value: i64) -> Result<Value> {
-        Ok(Value::I64(value))
+        Ok(Value::Static(StaticNode::I64(value)))
     }
 
     #[cfg(feature = "arbitrary_precision")]
@@ -104,7 +104,7 @@ impl serde::Serializer for Serializer {
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<Value> {
         #[allow(clippy::cast_possible_wrap)]
-        Ok(Value::I64(value as i64))
+        Ok(Value::Static(StaticNode::I64(value as i64)))
     }
 
     #[cfg(feature = "arbitrary_precision")]
@@ -121,7 +121,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_f64(self, value: f64) -> Result<Value> {
-        Ok(Value::F64(value))
+        Ok(Value::Static(StaticNode::F64(value)))
     }
 
     #[inline]
@@ -142,7 +142,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_unit(self) -> Result<Value> {
-        Ok(Value::Null)
+        Ok(Value::Static(StaticNode::Null))
     }
 
     #[inline]

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -11,7 +11,7 @@ use crate::Deserializer;
 pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::if_not_else, mutable_transmutes)]
+    #[allow(clippy::if_not_else, mutable_transmutes, clippy::transmute_ptr_to_ptr)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -12,7 +12,7 @@ pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub(crate) fn parse_str_(&mut self, idx: usize) -> Result<&'de str> {
+    pub(crate) fn parse_str_(&mut self, mut idx: usize) -> Result<&'de str> {
         // Add 1 to skip the initial "
         idx += 1;
         let mut padding = [0_u8; 32];

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -12,9 +12,9 @@ pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub(crate) fn parse_str_(&mut self) -> Result<&'de str> {
+    pub(crate) fn parse_str_(&mut self, idx: usize) -> Result<&'de str> {
         // Add 1 to skip the initial "
-        let idx = self.iidx + 1;
+        idx += 1;
         let mut padding = [0_u8; 32];
         //let mut read: usize = 0;
 

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -12,7 +12,13 @@ pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub(crate) fn parse_str_(&mut self, mut idx: usize) -> Result<&'de str> {
+    pub fn parse_str_<'invoke>(
+        input: &'de [u8],
+        buffer: &'invoke mut [u8],
+        mut idx: usize,
+    ) -> Result<&'de str> {
+        use ErrorType::*;
+        let input: &mut [u8] = unsafe { std::mem::transmute(input) };
         // Add 1 to skip the initial "
         idx += 1;
         let mut padding = [0_u8; 32];
@@ -22,7 +28,7 @@ impl<'de> Deserializer<'de> {
         // This is safe since we check sub's lenght in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
-        let src: &[u8] = unsafe { &self.input.get_unchecked(idx..) };
+        let src: &[u8] = unsafe { input.get_unchecked(idx..) };
         let mut src_i: usize = 0;
         let mut len = src_i;
         loop {
@@ -70,7 +76,7 @@ impl<'de> Deserializer<'de> {
 
                 len += quote_dist as usize;
                 unsafe {
-                    let v = self.input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -92,7 +98,6 @@ impl<'de> Deserializer<'de> {
         }
 
         let mut dst_i: usize = 0;
-        let dst: &mut [u8] = &mut self.strings;
 
         // To be more conform with upstream
         #[allow(clippy::if_not_else)]
@@ -116,7 +121,7 @@ impl<'de> Deserializer<'de> {
 
             #[allow(clippy::cast_ptr_alignment)]
             unsafe {
-                _mm_storeu_si128(dst.as_mut_ptr().add(dst_i) as *mut __m128i, v)
+                _mm_storeu_si128(buffer.as_mut_ptr().add(dst_i) as *mut __m128i, v)
             };
 
             // store to dest unconditionally - we can overwrite the bits we don't like
@@ -146,12 +151,11 @@ impl<'de> Deserializer<'de> {
 
                 dst_i += quote_dist as usize;
                 unsafe {
-                    self.input
+                    input
                         .get_unchecked_mut(idx + len..idx + len + dst_i)
-                        .clone_from_slice(&self.strings.get_unchecked(..dst_i));
-                    let v = self.input.get_unchecked(idx..idx + len + dst_i) as *const [u8]
-                        as *const str;
-                    self.str_offset += dst_i as usize;
+                        .clone_from_slice(&buffer.get_unchecked(..dst_i));
+                    let v =
+                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
                     return Ok(&*v);
                 }
 
@@ -170,14 +174,14 @@ impl<'de> Deserializer<'de> {
                     dst_i += bs_dist as usize;
                     let (o, s) = if let Ok(r) =
                         handle_unicode_codepoint(unsafe { src.get_unchecked(src_i..) }, unsafe {
-                            dst.get_unchecked_mut(dst_i..)
+                            buffer.get_unchecked_mut(dst_i..)
                         }) {
                         r
                     } else {
-                        return Err(self.error(ErrorType::InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
                     if o == 0 {
-                        return Err(self.error(ErrorType::InvlaidUnicodeCodepoint));
+                        return Err(Self::raw_error(src_i, 'u', InvlaidUnicodeCodepoint));
                     };
                     // We moved o steps forword at the destiation and 6 on the source
                     src_i += s;
@@ -190,10 +194,10 @@ impl<'de> Deserializer<'de> {
                     let escape_result: u8 =
                         unsafe { *ESCAPE_MAP.get_unchecked(escape_char as usize) };
                     if escape_result == 0 {
-                        return Err(self.error(ErrorType::InvalidEscape));
+                        return Err(Self::raw_error(src_i, escape_char as char, InvalidEscape));
                     }
                     unsafe {
-                        *dst.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
+                        *buffer.get_unchecked_mut(dst_i + bs_dist as usize) = escape_result;
                     }
                     src_i += bs_dist as usize + 2;
                     dst_i += bs_dist as usize + 1;

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -11,6 +11,7 @@ use crate::Deserializer;
 pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
+    #[allow(clippy::if_not_else, mutable_transmutes)]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -264,7 +264,7 @@ impl<'de> Deserializer<'de> {
                 unsafe {
                     res.set_len(r_i);
                 };
-                return Err(Error::new(i, idx, c as char, ErrorType::InternalError));
+                return Err(Error::new(idx, c as char, ErrorType::InternalError));
             };
             ($t:expr) => {
                 // We need to ensure that rust doens't
@@ -274,7 +274,7 @@ impl<'de> Deserializer<'de> {
                 unsafe {
                     res.set_len(r_i);
                 };
-                return Err(Error::new(i, idx, c as char, $t));
+                return Err(Error::new(idx, c as char, $t));
             };
         }
         // State start, we pull this outside of the

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -11,8 +11,6 @@ use crate::neon::stage1::SIMDJSON_PADDING;
 use crate::sse42::stage1::SIMDJSON_PADDING;
 use crate::value::tape::*;
 use crate::{Deserializer, Error, ErrorType, Result};
-use float_cmp::approx_eq;
-use std::fmt;
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
 #[allow(clippy::cast_ptr_alignment)]
@@ -89,37 +87,6 @@ enum StackState {
     Start,
     Object,
     Array,
-}
-
-#[cfg_attr(tarpaulin, skip)]
-impl<'v> fmt::Display for StaticNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Null => write!(f, "null"),
-            Self::Bool(b) => write!(f, "{}", b),
-            Self::I64(n) => write!(f, "{}", n),
-            Self::U64(n) => write!(f, "{}", n),
-            Self::F64(n) => write!(f, "{}", n),
-        }
-    }
-}
-
-#[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
-impl<'a> PartialEq for StaticNode {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Null, Self::Null) => true,
-            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
-            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
-            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
-            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
-            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
-            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
-            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
-            _ => false,
-        }
-    }
 }
 
 impl<'de> Deserializer<'de> {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -91,19 +91,30 @@ enum StackState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum Tape<'input> {
+/// Tape node
+pub enum Tape<'input> {
+    /// string
     String(&'input str),
+    /// Object
     Object(usize),
+    /// array
     Array(usize),
+    /// static value
     Static(StaticTape),
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Static tape value
 pub enum StaticTape {
+    /// i64
     I64(i64),
+    /// u64
     U64(u64),
+    /// f64
     F64(f64),
+    /// bool
     Bool(bool),
+    /// nnull
     Null,
 }
 

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -101,6 +101,7 @@ pub(crate) enum CharType {
 }
 
 impl<'de> Deserializer<'de> {
+    #[allow(clippy::cognitive_complexity)]
     pub fn validate(
         input: &[u8],
         structural_indexes: &[u32],

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -509,8 +509,7 @@ impl<'de> Deserializer<'de> {
                     depth -= 1;
                     unsafe {
                         match res.get_unchecked_mut(last_start) {
-                            Node::Array(ref mut len) => *len = cnt,
-                            Node::Object(ref mut len) => *len = cnt,
+                            Node::Array(ref mut len) | Node::Object(ref mut len) => *len = cnt,
                             _ => unreachable!(),
                         };
                     }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -92,8 +92,7 @@ enum StackState {
 pub(crate) enum CharType {
     String,
     Object,
-    PosNum,
-    NegNum,
+    Number(bool),
     True,
     False,
     Null,
@@ -105,11 +104,11 @@ impl<'de> Deserializer<'de> {
     pub fn validate(input: &[u8], structural_indexes: &[u32]) -> Result<(Vec<(CharType, u32)>)> {
         // While a valid json can have at max len/2 (`[[[]]]`)elements that are relevant
         // a invalid json might exceed this `[[[[[[` and we need to pretect against that.
-        let mut res = Vec::with_capacity(structural_indexes.len() + 1);
+        let mut res = Vec::with_capacity(structural_indexes.len());
         let mut stack = Vec::with_capacity(structural_indexes.len());
         unsafe {
             stack.set_len(structural_indexes.len());
-            res.set_len(structural_indexes.len() + 1);
+            res.set_len(structural_indexes.len());
         }
 
         let mut depth: usize = 0;
@@ -355,7 +354,7 @@ impl<'de> Deserializer<'de> {
                 }
             }
             b'-' => {
-                insert_res!(CharType::NegNum, idx);
+                insert_res!(CharType::Number(true), idx);
                 if si.next().is_none() {
                     return finish_res!();
                 } else {
@@ -363,7 +362,7 @@ impl<'de> Deserializer<'de> {
                 }
             }
             b'0'..=b'9' => {
-                insert_res!(CharType::PosNum, idx);
+                insert_res!(CharType::Number(false), idx);
                 if si.next().is_none() {
                     return finish_res!();
                 } else {
@@ -416,11 +415,11 @@ impl<'de> Deserializer<'de> {
                             object_continue!();
                         }
                         b'-' => {
-                            insert_res!(CharType::NegNum, idx);
+                            insert_res!(CharType::Number(true), idx);
                             object_continue!();
                         }
                         b'0'..=b'9' => {
-                            insert_res!(CharType::PosNum, idx);
+                            insert_res!(CharType::Number(false), idx);
                             object_continue!();
                         }
                         b'{' => {
@@ -515,11 +514,11 @@ impl<'de> Deserializer<'de> {
                             array_continue!();
                         }
                         b'-' => {
-                            insert_res!(CharType::NegNum, idx);
+                            insert_res!(CharType::Number(true), idx);
                             array_continue!();
                         }
                         b'0'..=b'9' => {
-                            insert_res!(CharType::PosNum, idx);
+                            insert_res!(CharType::Number(false), idx);
                             array_continue!();
                         }
                         b'{' => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -55,6 +55,8 @@ pub mod borrowed;
 pub(crate) mod generator;
 /// Owned, lifetimeless version of the value for times when lifetimes are to be avoided
 pub mod owned;
+/// Tape implementation
+pub mod tape;
 pub use self::borrowed::{to_value as to_borrowed_value, Value as BorrowedValue};
 pub use self::owned::{to_value as to_owned_value, Value as OwnedValue};
 use halfbrown::HashMap;

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -4,8 +4,9 @@ mod cmp;
 mod from;
 mod serialize;
 
+use crate::stage2::CharType;
 use crate::value::{ValueTrait, ValueType};
-use crate::{stry, unlikely, Deserializer, ErrorType, Result};
+use crate::{stry, Deserializer, Result};
 use halfbrown::HashMap;
 use std::borrow::Cow;
 use std::convert::TryFrom;
@@ -272,45 +273,37 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            b'"' => self.de.parse_str_().map(Value::from),
-            b'-' => self.de.parse_number_root(true).map(Value::from),
-            b'0'..=b'9' => self.de.parse_number_root(false).map(Value::from),
-            b'n' => Ok(Value::Null),
-            b't' => Ok(Value::Bool(true)),
-            b'f' => Ok(Value::Bool(false)),
-            b'[' => self.parse_array(),
-            b'{' => self.parse_map(),
-            _c => Err(self.de.error(ErrorType::UnexpectedCharacter)),
+            CharType::String => self.de.parse_str_().map(Value::from),
+            CharType::Null => Ok(Value::Null),
+            CharType::True => Ok(Value::Bool(true)),
+            CharType::False => Ok(Value::Bool(false)),
+            CharType::NegNum => self.de.parse_number_root(true).map(Value::from),
+            CharType::PosNum => self.de.parse_number_root(false).map(Value::from),
+            CharType::Array => self.parse_array(),
+            CharType::Object => self.parse_map(),
         }
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            b'"' => self.de.parse_str_().map(Value::from),
-            b'-' => self.de.parse_number_(true).map(Value::from),
-            b'0'..=b'9' => self.de.parse_number_(false).map(Value::from),
-            b'n' => Ok(Value::Null),
-            b't' => Ok(Value::Bool(true)),
-            b'f' => Ok(Value::Bool(false)),
-            b'[' => self.parse_array(),
-            b'{' => self.parse_map(),
-            _c => Err(self.de.error(ErrorType::UnexpectedCharacter)),
+            CharType::String => self.de.parse_str_().map(Value::from),
+            CharType::Null => Ok(Value::Null),
+            CharType::True => Ok(Value::Bool(true)),
+            CharType::False => Ok(Value::Bool(false)),
+            CharType::NegNum => self.de.parse_number_(true).map(Value::from),
+            CharType::PosNum => self.de.parse_number_(false).map(Value::from),
+            CharType::Array => self.parse_array(),
+            CharType::Object => self.parse_map(),
         }
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_array(&mut self) -> Result<Value<'de>> {
         let es = self.de.count_elements();
-        if unlikely!(es == 0) {
-            self.de.skip();
-            return Ok(Value::Array(Vec::new()));
-        }
         let mut res = Vec::with_capacity(es);
-
         for _i in 0..es {
             res.push(stry!(self.parse_value()));
-            self.de.skip();
         }
         Ok(Value::Array(res))
     }
@@ -319,11 +312,6 @@ impl<'de> BorrowDeserializer<'de> {
     fn parse_map(&mut self) -> Result<Value<'de>> {
         // We short cut for empty arrays
         let es = self.de.count_elements();
-
-        if unlikely!(es == 0) {
-            self.de.skip();
-            return Ok(Value::from(Object::new()));
-        }
 
         let mut res = Object::with_capacity(es);
 
@@ -335,9 +323,7 @@ impl<'de> BorrowDeserializer<'de> {
             let key = stry!(self.de.parse_str_());
             // We have to call parse short str twice since parse_short_str
             // does not move the cursor forward
-            self.de.skip();
             res.insert_nocheck(key.into(), stry!(self.parse_value()));
-            self.de.skip();
         }
         Ok(Value::from(res))
     }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -273,7 +273,7 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            Tape::String(idx) => self.de.parse_str_(idx).map(Value::from),
+            Tape::String(s) => Ok(Value::from(s)),
             Tape::Null => Ok(Value::Null),
             Tape::True => Ok(Value::Bool(true)),
             Tape::False => Ok(Value::Bool(false)),
@@ -317,10 +317,7 @@ impl<'de> BorrowDeserializer<'de> {
         // Since we checked if it's empty we know that we at least have one
         // element so we eat this
         for _ in 0..len {
-            if let Tape::String(idx) = self.de.next_() {
-                let key = stry!(self.de.parse_str_(idx));
-                // We have to call parse short str twice since parse_short_str
-                // does not move the cursor forward
+            if let Tape::String(key) = self.de.next_() {
                 res.insert_nocheck(key.into(), stry!(self.parse()));
             } else {
                 unreachable!()

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -273,52 +273,63 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            CharType::String => self.de.parse_str_().map(Value::from),
-            CharType::Null => Ok(Value::Null),
-            CharType::True => Ok(Value::Bool(true)),
-            CharType::False => Ok(Value::Bool(false)),
-            CharType::NegNum => self.de.parse_number_root(true).map(Value::from),
-            CharType::PosNum => self.de.parse_number_root(false).map(Value::from),
-            CharType::Array => self.parse_array(),
-            CharType::Object => self.parse_map(),
+            (CharType::String, _) => self.de.parse_str_().map(Value::from),
+            (CharType::Null, _) => Ok(Value::Null),
+            (CharType::True, _) => Ok(Value::Bool(true)),
+            (CharType::False, _) => Ok(Value::Bool(false)),
+            (CharType::NegNum, _) => self.de.parse_number_root(true).map(Value::from),
+            (CharType::PosNum, _) => self.de.parse_number_root(false).map(Value::from),
+            (CharType::Array, len) => self.parse_array(len),
+            (CharType::Object, len) => self.parse_map(len),
         }
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            CharType::String => self.de.parse_str_().map(Value::from),
-            CharType::Null => Ok(Value::Null),
-            CharType::True => Ok(Value::Bool(true)),
-            CharType::False => Ok(Value::Bool(false)),
-            CharType::NegNum => self.de.parse_number_(true).map(Value::from),
-            CharType::PosNum => self.de.parse_number_(false).map(Value::from),
-            CharType::Array => self.parse_array(),
-            CharType::Object => self.parse_map(),
+            (CharType::String, _) => self.de.parse_str_().map(Value::from),
+            (CharType::Null, _) => Ok(Value::Null),
+            (CharType::True, _) => Ok(Value::Bool(true)),
+            (CharType::False, _) => Ok(Value::Bool(false)),
+            (CharType::NegNum, _) => self.de.parse_number_(true).map(Value::from),
+            (CharType::PosNum, _) => self.de.parse_number_(false).map(Value::from),
+            (CharType::Array, len) => self.parse_array(len),
+            (CharType::Object, len) => self.parse_map(len),
         }
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    fn parse_array(&mut self) -> Result<Value<'de>> {
-        let es = self.de.count_elements();
-        let mut res = Vec::with_capacity(es);
-        for _i in 0..es {
-            res.push(stry!(self.parse_value()));
+    fn parse_array(&mut self, len: usize) -> Result<Value<'de>> {
+        // Rust doens't optimize the normal loop away here
+        // so we write our own avoiding the lenght
+        // checks during push
+        let mut res = Vec::with_capacity(len);
+        unsafe {
+            res.set_len(len);
+            for i in 0..len {
+                // We have to handle errors manyally here
+                // this is because if we encouter an error we have to set
+                // the lenght of the array to the correct value so rust can
+                // free the right memory
+                match self.parse_value() {
+                    Ok(r) => std::ptr::write(res.get_unchecked_mut(i), r),
+                    Err(e) => {
+                        res.set_len(i);
+                        return Err(e);
+                    }
+                };
+            }
         }
         Ok(Value::Array(res))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    fn parse_map(&mut self) -> Result<Value<'de>> {
-        // We short cut for empty arrays
-        let es = self.de.count_elements();
-
-        let mut res = Object::with_capacity(es);
+    fn parse_map(&mut self, len: usize) -> Result<Value<'de>> {
+        let mut res = Object::with_capacity(len);
 
         // Since we checked if it's empty we know that we at least have one
         // element so we eat this
-
-        for _ in 0..es {
+        for _ in 0..len {
             self.de.skip();
             let key = stry!(self.de.parse_str_());
             // We have to call parse short str twice since parse_short_str

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -273,28 +273,34 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            (CharType::String, _) => self.de.parse_str_().map(Value::from),
+            (CharType::String, idx) => self.de.parse_str_(idx as usize).map(Value::from),
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, _) => self.de.parse_number_root(true).map(Value::from),
-            (CharType::PosNum, _) => self.de.parse_number_root(false).map(Value::from),
-            (CharType::Array, len) => self.parse_array(len),
-            (CharType::Object, len) => self.parse_map(len),
+            (CharType::NegNum, idx) => self
+                .de
+                .parse_number_root(idx as usize, true)
+                .map(Value::from),
+            (CharType::PosNum, idx) => self
+                .de
+                .parse_number_root(idx as usize, false)
+                .map(Value::from),
+            (CharType::Array, len) => self.parse_array(len as usize),
+            (CharType::Object, len) => self.parse_map(len as usize),
         }
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            (CharType::String, _) => self.de.parse_str_().map(Value::from),
+            (CharType::String, idx) => self.de.parse_str_(idx as usize).map(Value::from),
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, _) => self.de.parse_number_(true).map(Value::from),
-            (CharType::PosNum, _) => self.de.parse_number_(false).map(Value::from),
-            (CharType::Array, len) => self.parse_array(len),
-            (CharType::Object, len) => self.parse_map(len),
+            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
+            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
+            (CharType::Array, len) => self.parse_array(len as usize),
+            (CharType::Object, len) => self.parse_map(len as usize),
         }
     }
 
@@ -330,8 +336,8 @@ impl<'de> BorrowDeserializer<'de> {
         // Since we checked if it's empty we know that we at least have one
         // element so we eat this
         for _ in 0..len {
-            self.de.skip();
-            let key = stry!(self.de.parse_str_());
+            let idx = self.de.next_().1;
+            let key = stry!(self.de.parse_str_(idx as usize));
             // We have to call parse short str twice since parse_short_str
             // does not move the cursor forward
             res.insert_nocheck(key.into(), stry!(self.parse_value()));

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -277,9 +277,13 @@ impl<'de> BorrowDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::Number(neg), idx) => self
+            (CharType::NegNum, idx) => self
                 .de
-                .parse_number_root(idx as usize, neg)
+                .parse_number_root(idx as usize, true)
+                .map(Value::from),
+            (CharType::PosNum, idx) => self
+                .de
+                .parse_number_root(idx as usize, false)
                 .map(Value::from),
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
@@ -293,9 +297,8 @@ impl<'de> BorrowDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::Number(neg), idx) => {
-                self.de.parse_number_(idx as usize, neg).map(Value::from)
-            }
+            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
+            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
         }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -277,13 +277,9 @@ impl<'de> BorrowDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, idx) => self
+            (CharType::Number(neg), idx) => self
                 .de
-                .parse_number_root(idx as usize, true)
-                .map(Value::from),
-            (CharType::PosNum, idx) => self
-                .de
-                .parse_number_root(idx as usize, false)
+                .parse_number_root(idx as usize, neg)
                 .map(Value::from),
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
@@ -297,8 +293,9 @@ impl<'de> BorrowDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
-            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
+            (CharType::Number(neg), idx) => {
+                self.de.parse_number_(idx as usize, neg).map(Value::from)
+            }
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
         }

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -4,7 +4,7 @@ mod cmp;
 mod from;
 mod serialize;
 
-use crate::stage2::CharType;
+use crate::stage2::Tape;
 use crate::value::{ValueTrait, ValueType};
 use crate::{stry, Deserializer, Result};
 use halfbrown::HashMap;
@@ -273,34 +273,15 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            (CharType::String, idx) => self.de.parse_str_(idx as usize).map(Value::from),
-            (CharType::Null, _) => Ok(Value::Null),
-            (CharType::True, _) => Ok(Value::Bool(true)),
-            (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, idx) => self
-                .de
-                .parse_number_root(idx as usize, true)
-                .map(Value::from),
-            (CharType::PosNum, idx) => self
-                .de
-                .parse_number_root(idx as usize, false)
-                .map(Value::from),
-            (CharType::Array, len) => self.parse_array(len as usize),
-            (CharType::Object, len) => self.parse_map(len as usize),
-        }
-    }
-
-    #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    fn parse_value(&mut self) -> Result<Value<'de>> {
-        match self.de.next_() {
-            (CharType::String, idx) => self.de.parse_str_(idx as usize).map(Value::from),
-            (CharType::Null, _) => Ok(Value::Null),
-            (CharType::True, _) => Ok(Value::Bool(true)),
-            (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
-            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
-            (CharType::Array, len) => self.parse_array(len as usize),
-            (CharType::Object, len) => self.parse_map(len as usize),
+            Tape::String(idx) => self.de.parse_str_(idx).map(Value::from),
+            Tape::Null => Ok(Value::Null),
+            Tape::True => Ok(Value::Bool(true)),
+            Tape::False => Ok(Value::Bool(false)),
+            Tape::F64(n) => Ok(Value::F64(n)),
+            Tape::I64(n) => Ok(Value::I64(n)),
+            Tape::U64(n) => Ok(Value::U64(n)),
+            Tape::Array(len) => self.parse_array(len),
+            Tape::Object(len) => self.parse_map(len),
         }
     }
 
@@ -317,7 +298,7 @@ impl<'de> BorrowDeserializer<'de> {
                 // this is because if we encouter an error we have to set
                 // the lenght of the array to the correct value so rust can
                 // free the right memory
-                match self.parse_value() {
+                match self.parse() {
                     Ok(r) => std::ptr::write(res.get_unchecked_mut(i), r),
                     Err(e) => {
                         res.set_len(i);
@@ -336,11 +317,14 @@ impl<'de> BorrowDeserializer<'de> {
         // Since we checked if it's empty we know that we at least have one
         // element so we eat this
         for _ in 0..len {
-            let idx = self.de.next_().1;
-            let key = stry!(self.de.parse_str_(idx as usize));
-            // We have to call parse short str twice since parse_short_str
-            // does not move the cursor forward
-            res.insert_nocheck(key.into(), stry!(self.parse_value()));
+            if let Tape::String(idx) = self.de.next_() {
+                let key = stry!(self.de.parse_str_(idx));
+                // We have to call parse short str twice since parse_short_str
+                // does not move the cursor forward
+                res.insert_nocheck(key.into(), stry!(self.parse()));
+            } else {
+                unreachable!()
+            }
         }
         Ok(Value::from(res))
     }

--- a/src/value/borrowed/cmp.rs
+++ b/src/value/borrowed/cmp.rs
@@ -1,20 +1,12 @@
 use super::Value;
 use crate::{OwnedValue, ValueTrait};
-use float_cmp::approx_eq;
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl<'a> PartialEq for Value<'a> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Null, Self::Null) => true,
-            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
-            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
-            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
-            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
-            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
-            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
-            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
+            (Self::Static(s1), Self::Static(s2)) => s1 == s2,
             (Self::String(v1), Self::String(v2)) => v1.eq(v2),
             (Self::Array(v1), Self::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), Self::Object(v2)) => v1.eq(v2),

--- a/src/value/borrowed/from.rs
+++ b/src/value/borrowed/from.rs
@@ -1,29 +1,18 @@
 use super::{Object, Value};
-use crate::numberparse::Number;
+use crate::stage2::StaticTape;
 use crate::OwnedValue;
 use std::borrow::Cow;
 use std::iter::FromIterator;
-
-impl<'a> From<Number> for Value<'a> {
-    #[inline]
-    fn from(n: Number) -> Self {
-        match n {
-            Number::F64(n) => Value::F64(n),
-            Number::I64(n) => Value::I64(n),
-            Number::U64(n) => Value::U64(n),
-        }
-    }
-}
 
 impl<'a> From<OwnedValue> for Value<'a> {
     #[inline]
     fn from(b: OwnedValue) -> Self {
         match b {
-            OwnedValue::Null => Value::Null,
-            OwnedValue::Bool(b) => Value::Bool(b),
-            OwnedValue::F64(f) => Value::F64(f),
-            OwnedValue::I64(i) => Value::I64(i),
-            OwnedValue::U64(i) => Value::U64(i),
+            OwnedValue::Null => Value::Static(StaticTape::Null),
+            OwnedValue::Bool(b) => Value::Static(StaticTape::Bool(b)),
+            OwnedValue::F64(f) => Value::Static(StaticTape::F64(f)),
+            OwnedValue::I64(i) => Value::Static(StaticTape::I64(i)),
+            OwnedValue::U64(i) => Value::Static(StaticTape::U64(i)),
             OwnedValue::String(s) => Value::from(s.to_string()),
             OwnedValue::Array(a) => a.into_iter().collect(),
             OwnedValue::Object(m) => m.into_iter().collect(),
@@ -57,13 +46,13 @@ impl<'v> From<String> for Value<'v> {
 impl<'v> From<bool> for Value<'v> {
     #[inline]
     fn from(b: bool) -> Self {
-        Value::Bool(b)
+        Value::Static(StaticTape::Bool(b))
     }
 }
 impl<'v> From<()> for Value<'v> {
     #[inline]
     fn from(_b: ()) -> Self {
-        Value::Null
+        Value::Static(StaticTape::Null)
     }
 }
 
@@ -71,28 +60,28 @@ impl<'v> From<()> for Value<'v> {
 impl<'v> From<i8> for Value<'v> {
     #[inline]
     fn from(i: i8) -> Self {
-        Value::I64(i64::from(i))
+        Value::Static(StaticTape::I64(i64::from(i)))
     }
 }
 
 impl<'v> From<i16> for Value<'v> {
     #[inline]
     fn from(i: i16) -> Self {
-        Value::I64(i64::from(i))
+        Value::Static(StaticTape::I64(i64::from(i)))
     }
 }
 
 impl<'v> From<i32> for Value<'v> {
     #[inline]
     fn from(i: i32) -> Self {
-        Value::I64(i64::from(i))
+        Value::Static(StaticTape::I64(i64::from(i)))
     }
 }
 
 impl<'v> From<i64> for Value<'v> {
     #[inline]
     fn from(i: i64) -> Self {
-        Value::I64(i)
+        Value::Static(StaticTape::I64(i))
     }
 }
 
@@ -100,35 +89,35 @@ impl<'v> From<i64> for Value<'v> {
 impl<'v> From<u8> for Value<'v> {
     #[inline]
     fn from(i: u8) -> Self {
-        Self::U64(u64::from(i))
+        Self::Static(StaticTape::U64(u64::from(i)))
     }
 }
 
 impl<'v> From<u16> for Value<'v> {
     #[inline]
     fn from(i: u16) -> Self {
-        Self::U64(u64::from(i))
+        Self::Static(StaticTape::U64(u64::from(i)))
     }
 }
 
 impl<'v> From<u32> for Value<'v> {
     #[inline]
     fn from(i: u32) -> Self {
-        Self::U64(u64::from(i))
+        Self::Static(StaticTape::U64(u64::from(i)))
     }
 }
 
 impl<'v> From<u64> for Value<'v> {
     #[inline]
     fn from(i: u64) -> Self {
-        Value::U64(i)
+        Value::Static(StaticTape::U64(i))
     }
 }
 
 impl<'v> From<usize> for Value<'v> {
     #[inline]
     fn from(i: usize) -> Self {
-        Self::U64(i as u64)
+        Self::Static(StaticTape::U64(i as u64))
     }
 }
 
@@ -136,14 +125,14 @@ impl<'v> From<usize> for Value<'v> {
 impl<'v> From<f32> for Value<'v> {
     #[inline]
     fn from(f: f32) -> Self {
-        Value::F64(f64::from(f))
+        Value::Static(StaticTape::F64(f64::from(f)))
     }
 }
 
 impl<'v> From<f64> for Value<'v> {
     #[inline]
     fn from(f: f64) -> Self {
-        Value::F64(f)
+        Value::Static(StaticTape::F64(f))
     }
 }
 

--- a/src/value/borrowed/from.rs
+++ b/src/value/borrowed/from.rs
@@ -1,6 +1,6 @@
 use super::{Object, Value};
-use crate::stage2::StaticTape;
 use crate::OwnedValue;
+use crate::StaticNode;
 use std::borrow::Cow;
 use std::iter::FromIterator;
 
@@ -8,11 +8,7 @@ impl<'a> From<OwnedValue> for Value<'a> {
     #[inline]
     fn from(b: OwnedValue) -> Self {
         match b {
-            OwnedValue::Null => Value::Static(StaticTape::Null),
-            OwnedValue::Bool(b) => Value::Static(StaticTape::Bool(b)),
-            OwnedValue::F64(f) => Value::Static(StaticTape::F64(f)),
-            OwnedValue::I64(i) => Value::Static(StaticTape::I64(i)),
-            OwnedValue::U64(i) => Value::Static(StaticTape::U64(i)),
+            OwnedValue::Static(s) => Value::Static(s),
             OwnedValue::String(s) => Value::from(s.to_string()),
             OwnedValue::Array(a) => a.into_iter().collect(),
             OwnedValue::Object(m) => m.into_iter().collect(),
@@ -46,13 +42,13 @@ impl<'v> From<String> for Value<'v> {
 impl<'v> From<bool> for Value<'v> {
     #[inline]
     fn from(b: bool) -> Self {
-        Value::Static(StaticTape::Bool(b))
+        Value::Static(StaticNode::Bool(b))
     }
 }
 impl<'v> From<()> for Value<'v> {
     #[inline]
     fn from(_b: ()) -> Self {
-        Value::Static(StaticTape::Null)
+        Value::Static(StaticNode::Null)
     }
 }
 
@@ -60,28 +56,28 @@ impl<'v> From<()> for Value<'v> {
 impl<'v> From<i8> for Value<'v> {
     #[inline]
     fn from(i: i8) -> Self {
-        Value::Static(StaticTape::I64(i64::from(i)))
+        Value::Static(StaticNode::I64(i64::from(i)))
     }
 }
 
 impl<'v> From<i16> for Value<'v> {
     #[inline]
     fn from(i: i16) -> Self {
-        Value::Static(StaticTape::I64(i64::from(i)))
+        Value::Static(StaticNode::I64(i64::from(i)))
     }
 }
 
 impl<'v> From<i32> for Value<'v> {
     #[inline]
     fn from(i: i32) -> Self {
-        Value::Static(StaticTape::I64(i64::from(i)))
+        Value::Static(StaticNode::I64(i64::from(i)))
     }
 }
 
 impl<'v> From<i64> for Value<'v> {
     #[inline]
     fn from(i: i64) -> Self {
-        Value::Static(StaticTape::I64(i))
+        Value::Static(StaticNode::I64(i))
     }
 }
 
@@ -89,35 +85,35 @@ impl<'v> From<i64> for Value<'v> {
 impl<'v> From<u8> for Value<'v> {
     #[inline]
     fn from(i: u8) -> Self {
-        Self::Static(StaticTape::U64(u64::from(i)))
+        Self::Static(StaticNode::U64(u64::from(i)))
     }
 }
 
 impl<'v> From<u16> for Value<'v> {
     #[inline]
     fn from(i: u16) -> Self {
-        Self::Static(StaticTape::U64(u64::from(i)))
+        Self::Static(StaticNode::U64(u64::from(i)))
     }
 }
 
 impl<'v> From<u32> for Value<'v> {
     #[inline]
     fn from(i: u32) -> Self {
-        Self::Static(StaticTape::U64(u64::from(i)))
+        Self::Static(StaticNode::U64(u64::from(i)))
     }
 }
 
 impl<'v> From<u64> for Value<'v> {
     #[inline]
     fn from(i: u64) -> Self {
-        Value::Static(StaticTape::U64(i))
+        Value::Static(StaticNode::U64(i))
     }
 }
 
 impl<'v> From<usize> for Value<'v> {
     #[inline]
     fn from(i: usize) -> Self {
-        Self::Static(StaticTape::U64(i as u64))
+        Self::Static(StaticNode::U64(i as u64))
     }
 }
 
@@ -125,14 +121,14 @@ impl<'v> From<usize> for Value<'v> {
 impl<'v> From<f32> for Value<'v> {
     #[inline]
     fn from(f: f32) -> Self {
-        Value::Static(StaticTape::F64(f64::from(f)))
+        Value::Static(StaticNode::F64(f64::from(f)))
     }
 }
 
 impl<'v> From<f64> for Value<'v> {
     #[inline]
     fn from(f: f64) -> Self {
-        Value::Static(StaticTape::F64(f))
+        Value::Static(StaticNode::F64(f))
     }
 }
 

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -5,6 +5,7 @@
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs
 
 use super::{Object, Value};
+use crate::stage2::StaticTape;
 use crate::stry;
 use crate::value::generator::*;
 use crate::value::ValueTrait;
@@ -83,13 +84,13 @@ trait Generator: BaseGenerator {
     #[inline(always)]
     fn write_json(&mut self, json: &Value) -> io::Result<()> {
         match *json {
-            Value::Null => self.write(b"null"),
+            Value::Static(StaticTape::Null) => self.write(b"null"),
+            Value::Static(StaticTape::I64(number)) => self.write_int(number),
+            Value::Static(StaticTape::U64(number)) => self.write_uint(number),
+            Value::Static(StaticTape::F64(number)) => self.write_float(number),
+            Value::Static(StaticTape::Bool(true)) => self.write(b"true"),
+            Value::Static(StaticTape::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
-            Value::I64(number) => self.write_int(number),
-            Value::U64(number) => self.write_uint(number),
-            Value::F64(number) => self.write_float(number),
-            Value::Bool(true) => self.write(b"true"),
-            Value::Bool(false) => self.write(b"false"),
             Value::Array(ref array) => {
                 stry!(self.write_char(b'['));
                 let mut iter = array.iter();
@@ -147,17 +148,18 @@ where
 #[cfg(test)]
 mod test {
     use super::Value;
+    use crate::stage2::StaticTape;
     #[test]
     fn null() {
-        assert_eq!(Value::Null.encode(), "null")
+        assert_eq!(Value::Static(StaticTape::Null).encode(), "null")
     }
     #[test]
     fn bool_true() {
-        assert_eq!(Value::Bool(true).encode(), "true")
+        assert_eq!(Value::Static(StaticTape::Bool(true)).encode(), "true")
     }
     #[test]
     fn bool_false() {
-        assert_eq!(Value::Bool(false).encode(), "false")
+        assert_eq!(Value::Static(StaticTape::Bool(false)).encode(), "false")
     }
     fn assert_str(from: &str, to: &str) {
         assert_eq!(Value::String(from.into()).encode(), to)

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -5,7 +5,7 @@
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs
 
 use super::{Object, Value};
-use crate::stage2::StaticTape;
+use crate::StaticNode;
 use crate::stry;
 use crate::value::generator::*;
 use crate::value::ValueTrait;
@@ -84,12 +84,12 @@ trait Generator: BaseGenerator {
     #[inline(always)]
     fn write_json(&mut self, json: &Value) -> io::Result<()> {
         match *json {
-            Value::Static(StaticTape::Null) => self.write(b"null"),
-            Value::Static(StaticTape::I64(number)) => self.write_int(number),
-            Value::Static(StaticTape::U64(number)) => self.write_uint(number),
-            Value::Static(StaticTape::F64(number)) => self.write_float(number),
-            Value::Static(StaticTape::Bool(true)) => self.write(b"true"),
-            Value::Static(StaticTape::Bool(false)) => self.write(b"false"),
+            Value::Static(StaticNode::Null) => self.write(b"null"),
+            Value::Static(StaticNode::I64(number)) => self.write_int(number),
+            Value::Static(StaticNode::U64(number)) => self.write_uint(number),
+            Value::Static(StaticNode::F64(number)) => self.write_float(number),
+            Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
+            Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
             Value::Array(ref array) => {
                 stry!(self.write_char(b'['));
@@ -148,18 +148,18 @@ where
 #[cfg(test)]
 mod test {
     use super::Value;
-    use crate::stage2::StaticTape;
+    use crate::StaticNode;
     #[test]
     fn null() {
-        assert_eq!(Value::Static(StaticTape::Null).encode(), "null")
+        assert_eq!(Value::Static(StaticNode::Null).encode(), "null")
     }
     #[test]
     fn bool_true() {
-        assert_eq!(Value::Static(StaticTape::Bool(true)).encode(), "true")
+        assert_eq!(Value::Static(StaticNode::Bool(true)).encode(), "true")
     }
     #[test]
     fn bool_false() {
-        assert_eq!(Value::Static(StaticTape::Bool(false)).encode(), "false")
+        assert_eq!(Value::Static(StaticNode::Bool(false)).encode(), "false")
     }
     fn assert_str(from: &str, to: &str) {
         assert_eq!(Value::String(from.into()).encode(), to)

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -5,10 +5,10 @@
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs
 
 use super::{Object, Value};
-use crate::StaticNode;
 use crate::stry;
 use crate::value::generator::*;
 use crate::value::ValueTrait;
+use crate::StaticNode;
 use std::io;
 use std::io::Write;
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -234,28 +234,34 @@ impl<'de> OwnedDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value> {
         match self.de.next_() {
-            (CharType::String, _) => self.de.parse_str_().map(Value::from),
+            (CharType::String, idx) => self.de.parse_str_(idx as usize).map(Value::from),
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, _) => self.de.parse_number_root(true).map(Value::from),
-            (CharType::PosNum, _) => self.de.parse_number_root(false).map(Value::from),
-            (CharType::Array, len) => self.parse_array(len),
-            (CharType::Object, len) => self.parse_map(len),
+            (CharType::NegNum, idx) => self
+                .de
+                .parse_number_root(idx as usize, true)
+                .map(Value::from),
+            (CharType::PosNum, idx) => self
+                .de
+                .parse_number_root(idx as usize, false)
+                .map(Value::from),
+            (CharType::Array, len) => self.parse_array(len as usize),
+            (CharType::Object, len) => self.parse_map(len as usize),
         }
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value> {
         match self.de.next_() {
-            (CharType::String, _) => self.de.parse_str_().map(Value::from),
+            (CharType::String, idx) => self.de.parse_str_(idx as usize).map(Value::from),
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, _) => self.de.parse_number_(true).map(Value::from),
-            (CharType::PosNum, _) => self.de.parse_number_(false).map(Value::from),
-            (CharType::Array, len) => self.parse_array(len),
-            (CharType::Object, len) => self.parse_map(len),
+            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
+            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
+            (CharType::Array, len) => self.parse_array(len as usize),
+            (CharType::Object, len) => self.parse_map(len as usize),
         }
     }
 
@@ -289,8 +295,8 @@ impl<'de> OwnedDeserializer<'de> {
         let mut res = Object::with_capacity(len);
 
         for _ in 0..len {
-            self.de.skip();
-            let key = stry!(self.de.parse_str_());
+            let idx = self.de.next_().1;
+            let key = stry!(self.de.parse_str_(idx as usize));
             // We have to call parse short str twice since parse_short_str
             // does not move the cursor forward
             res.insert_nocheck(key.into(), stry!(self.parse_value()));

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -6,7 +6,7 @@ mod serialize;
 
 use crate::stage2::Tape;
 use crate::value::{ValueTrait, ValueType};
-use crate::{stry, Deserializer, Result};
+use crate::{Deserializer, Result};
 use halfbrown::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -21,8 +21,10 @@ pub type Object = HashMap<String, Value>;
 /// owned memory whereever required thus returning a value without
 /// a lifetime.
 pub fn to_value(s: &mut [u8]) -> Result<Value> {
-    let de = stry!(Deserializer::from_slice(s));
-    Ok(OwnedDeserializer::from_deserializer(de).parse())
+    match Deserializer::from_slice(s) {
+        Ok(de) => Ok(OwnedDeserializer::from_deserializer(de).parse()),
+        Err(e) => Err(e),
+    }
 }
 
 /// Owned JSON-DOM Value, consider using the `ValueTrait`

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -238,13 +238,9 @@ impl<'de> OwnedDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, idx) => self
+            (CharType::Number(neg), idx) => self
                 .de
-                .parse_number_root(idx as usize, true)
-                .map(Value::from),
-            (CharType::PosNum, idx) => self
-                .de
-                .parse_number_root(idx as usize, false)
+                .parse_number_root(idx as usize, neg)
                 .map(Value::from),
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
@@ -258,8 +254,10 @@ impl<'de> OwnedDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
-            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
+            (CharType::Number(neg), idx) => {
+                self.de.parse_number_(idx as usize, neg).map(Value::from)
+            }
+
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
         }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -4,7 +4,7 @@ mod cmp;
 mod from;
 mod serialize;
 
-use crate::stage2::Tape;
+use crate::stage2::{StaticTape, Tape};
 use crate::value::{ValueTrait, ValueType};
 use crate::{Deserializer, Result};
 use halfbrown::HashMap;
@@ -236,13 +236,12 @@ impl<'de> OwnedDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Value {
         match self.de.next_() {
+            Tape::Static(StaticTape::Null) => Value::Null,
+            Tape::Static(StaticTape::Bool(b)) => Value::Bool(b),
+            Tape::Static(StaticTape::F64(n)) => Value::F64(n),
+            Tape::Static(StaticTape::I64(n)) => Value::I64(n),
+            Tape::Static(StaticTape::U64(n)) => Value::U64(n),
             Tape::String(s) => Value::from(s),
-            Tape::Null => Value::Null,
-            Tape::True => Value::Bool(true),
-            Tape::False => Value::Bool(false),
-            Tape::F64(n) => Value::F64(n),
-            Tape::I64(n) => Value::I64(n),
-            Tape::U64(n) => Value::U64(n),
             Tape::Array(len) => self.parse_array(len),
             Tape::Object(len) => self.parse_map(len),
         }

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -238,9 +238,13 @@ impl<'de> OwnedDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::Number(neg), idx) => self
+            (CharType::NegNum, idx) => self
                 .de
-                .parse_number_root(idx as usize, neg)
+                .parse_number_root(idx as usize, true)
+                .map(Value::from),
+            (CharType::PosNum, idx) => self
+                .de
+                .parse_number_root(idx as usize, false)
                 .map(Value::from),
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
@@ -254,10 +258,8 @@ impl<'de> OwnedDeserializer<'de> {
             (CharType::Null, _) => Ok(Value::Null),
             (CharType::True, _) => Ok(Value::Bool(true)),
             (CharType::False, _) => Ok(Value::Bool(false)),
-            (CharType::Number(neg), idx) => {
-                self.de.parse_number_(idx as usize, neg).map(Value::from)
-            }
-
+            (CharType::NegNum, idx) => self.de.parse_number_(idx as usize, true).map(Value::from),
+            (CharType::PosNum, idx) => self.de.parse_number_(idx as usize, false).map(Value::from),
             (CharType::Array, len) => self.parse_array(len as usize),
             (CharType::Object, len) => self.parse_map(len as usize),
         }

--- a/src/value/owned/cmp.rs
+++ b/src/value/owned/cmp.rs
@@ -1,4 +1,5 @@
 use super::Value;
+use crate::stage2::StaticTape;
 use crate::{BorrowedValue, ValueTrait};
 
 use float_cmp::approx_eq;
@@ -8,14 +9,20 @@ impl PartialEq<BorrowedValue<'_>> for Value {
     #[inline]
     fn eq(&self, other: &BorrowedValue<'_>) -> bool {
         match (self, other) {
-            (Self::Null, BorrowedValue::Null) => true,
-            (Self::Bool(v1), BorrowedValue::Bool(v2)) => v1.eq(v2),
-            (Self::I64(v1), BorrowedValue::I64(v2)) => v1.eq(v2),
-            (Self::U64(v1), BorrowedValue::U64(v2)) => v1.eq(v2),
+            (Self::Null, BorrowedValue::Static(StaticTape::Null)) => true,
+            (Self::Bool(v1), BorrowedValue::Static(StaticTape::Bool(v2))) => v1.eq(v2),
+            (Self::I64(v1), BorrowedValue::Static(StaticTape::I64(v2))) => v1.eq(v2),
+            (Self::U64(v1), BorrowedValue::Static(StaticTape::U64(v2))) => v1.eq(v2),
             // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
-            (Self::U64(v1), BorrowedValue::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
-            (Self::I64(v1), BorrowedValue::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
-            (Self::F64(v1), BorrowedValue::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            (Self::U64(v1), BorrowedValue::Static(StaticTape::I64(v2))) if *v2 >= 0 => {
+                (*v2 as u64).eq(v1)
+            }
+            (Self::I64(v1), BorrowedValue::Static(StaticTape::U64(v2))) if *v1 >= 0 => {
+                (*v1 as u64).eq(v2)
+            }
+            (Self::F64(v1), BorrowedValue::Static(StaticTape::F64(v2))) => {
+                approx_eq!(f64, *v1, *v2)
+            }
             (Self::String(v1), BorrowedValue::String(v2)) => v1.eq(v2),
             (Self::Array(v1), BorrowedValue::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), BorrowedValue::Object(v2)) => {

--- a/src/value/owned/cmp.rs
+++ b/src/value/owned/cmp.rs
@@ -1,28 +1,12 @@
 use super::Value;
-use crate::stage2::StaticTape;
 use crate::{BorrowedValue, ValueTrait};
-
-use float_cmp::approx_eq;
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl PartialEq<BorrowedValue<'_>> for Value {
     #[inline]
     fn eq(&self, other: &BorrowedValue<'_>) -> bool {
         match (self, other) {
-            (Self::Null, BorrowedValue::Static(StaticTape::Null)) => true,
-            (Self::Bool(v1), BorrowedValue::Static(StaticTape::Bool(v2))) => v1.eq(v2),
-            (Self::I64(v1), BorrowedValue::Static(StaticTape::I64(v2))) => v1.eq(v2),
-            (Self::U64(v1), BorrowedValue::Static(StaticTape::U64(v2))) => v1.eq(v2),
-            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
-            (Self::U64(v1), BorrowedValue::Static(StaticTape::I64(v2))) if *v2 >= 0 => {
-                (*v2 as u64).eq(v1)
-            }
-            (Self::I64(v1), BorrowedValue::Static(StaticTape::U64(v2))) if *v1 >= 0 => {
-                (*v1 as u64).eq(v2)
-            }
-            (Self::F64(v1), BorrowedValue::Static(StaticTape::F64(v2))) => {
-                approx_eq!(f64, *v1, *v2)
-            }
+            (Self::Static(s1), BorrowedValue::Static(s2)) => s1 == s2,
             (Self::String(v1), BorrowedValue::String(v2)) => v1.eq(v2),
             (Self::Array(v1), BorrowedValue::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), BorrowedValue::Object(v2)) => {
@@ -42,14 +26,7 @@ impl PartialEq for Value {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Null, Self::Null) => true,
-            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
-            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
-            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
-            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
-            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
-            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
-            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            (Self::Static(s1), Self::Static(s2)) => s1.eq(s2),
             (Self::String(v1), Self::String(v2)) => v1.eq(v2),
             (Self::Array(v1), Self::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), Self::Object(v2)) => v1.eq(v2),

--- a/src/value/owned/from.rs
+++ b/src/value/owned/from.rs
@@ -1,5 +1,6 @@
 use super::{Object, Value};
 use crate::numberparse::Number;
+use crate::stage2::StaticTape;
 use crate::BorrowedValue;
 use std::borrow::Cow;
 use std::iter::FromIterator;
@@ -19,11 +20,11 @@ impl From<crate::BorrowedValue<'_>> for Value {
     #[inline]
     fn from(b: BorrowedValue<'_>) -> Self {
         match b {
-            BorrowedValue::Null => Self::Null,
-            BorrowedValue::Bool(b) => Self::Bool(b),
-            BorrowedValue::F64(f) => Self::F64(f),
-            BorrowedValue::I64(i) => Self::I64(i),
-            BorrowedValue::U64(i) => Self::U64(i),
+            BorrowedValue::Static(StaticTape::Null) => Self::Null,
+            BorrowedValue::Static(StaticTape::Bool(b)) => Self::Bool(b),
+            BorrowedValue::Static(StaticTape::F64(f)) => Self::F64(f),
+            BorrowedValue::Static(StaticTape::I64(i)) => Self::I64(i),
+            BorrowedValue::Static(StaticTape::U64(i)) => Self::U64(i),
             BorrowedValue::String(s) => Self::from(s.to_string()),
             BorrowedValue::Array(a) => a.into_iter().collect(),
             BorrowedValue::Object(m) => m.into_iter().collect(),

--- a/src/value/owned/from.rs
+++ b/src/value/owned/from.rs
@@ -1,30 +1,13 @@
 use super::{Object, Value};
-use crate::numberparse::Number;
-use crate::stage2::StaticTape;
-use crate::BorrowedValue;
+use crate::{BorrowedValue, StaticNode};
 use std::borrow::Cow;
 use std::iter::FromIterator;
-
-impl From<Number> for Value {
-    #[inline]
-    fn from(n: Number) -> Self {
-        match n {
-            Number::F64(n) => Self::F64(n),
-            Number::I64(n) => Self::I64(n),
-            Number::U64(n) => Self::U64(n),
-        }
-    }
-}
 
 impl From<crate::BorrowedValue<'_>> for Value {
     #[inline]
     fn from(b: BorrowedValue<'_>) -> Self {
         match b {
-            BorrowedValue::Static(StaticTape::Null) => Self::Null,
-            BorrowedValue::Static(StaticTape::Bool(b)) => Self::Bool(b),
-            BorrowedValue::Static(StaticTape::F64(f)) => Self::F64(f),
-            BorrowedValue::Static(StaticTape::I64(i)) => Self::I64(i),
-            BorrowedValue::Static(StaticTape::U64(i)) => Self::U64(i),
+            BorrowedValue::Static(s) => Self::Static(s),
             BorrowedValue::String(s) => Self::from(s.to_string()),
             BorrowedValue::Array(a) => a.into_iter().collect(),
             BorrowedValue::Object(m) => m.into_iter().collect(),
@@ -67,14 +50,14 @@ impl From<&String> for Value {
 impl From<bool> for Value {
     #[inline]
     fn from(b: bool) -> Self {
-        Self::Bool(b)
+        Self::Static(StaticNode::Bool(b))
     }
 }
 
 impl From<()> for Value {
     #[inline]
     fn from(_b: ()) -> Self {
-        Self::Null
+        Self::Static(StaticNode::Null)
     }
 }
 
@@ -82,28 +65,28 @@ impl From<()> for Value {
 impl From<i8> for Value {
     #[inline]
     fn from(i: i8) -> Self {
-        Self::I64(i64::from(i))
+        Self::Static(StaticNode::I64(i64::from(i)))
     }
 }
 
 impl From<i16> for Value {
     #[inline]
     fn from(i: i16) -> Self {
-        Self::I64(i64::from(i))
+        Self::Static(StaticNode::I64(i64::from(i)))
     }
 }
 
 impl From<i32> for Value {
     #[inline]
     fn from(i: i32) -> Self {
-        Self::I64(i64::from(i))
+        Self::Static(StaticNode::I64(i64::from(i)))
     }
 }
 
 impl From<i64> for Value {
     #[inline]
     fn from(i: i64) -> Self {
-        Self::I64(i)
+        Self::Static(StaticNode::I64(i))
     }
 }
 
@@ -111,21 +94,21 @@ impl From<i64> for Value {
 impl From<u8> for Value {
     #[inline]
     fn from(i: u8) -> Self {
-        Self::U64(u64::from(i))
+        Self::Static(StaticNode::U64(u64::from(i)))
     }
 }
 
 impl From<u16> for Value {
     #[inline]
     fn from(i: u16) -> Self {
-        Self::U64(u64::from(i))
+        Self::Static(StaticNode::U64(u64::from(i)))
     }
 }
 
 impl From<u32> for Value {
     #[inline]
     fn from(i: u32) -> Self {
-        Self::U64(u64::from(i))
+        Self::Static(StaticNode::U64(u64::from(i)))
     }
 }
 
@@ -133,15 +116,14 @@ impl From<u64> for Value {
     #[inline]
     fn from(i: u64) -> Self {
         #[allow(clippy::cast_possible_wrap)]
-        Self::U64(i)
+        Self::Static(StaticNode::U64(i))
     }
 }
 
 impl From<usize> for Value {
     #[inline]
     fn from(i: usize) -> Self {
-        #[allow(clippy::cast_possible_wrap)]
-        Self::U64(i as u64)
+        Self::Static(StaticNode::U64(i as u64))
     }
 }
 
@@ -149,14 +131,14 @@ impl From<usize> for Value {
 impl From<f32> for Value {
     #[inline]
     fn from(f: f32) -> Self {
-        Self::F64(f64::from(f))
+        Self::Static(StaticNode::F64(f64::from(f)))
     }
 }
 
 impl From<f64> for Value {
     #[inline]
     fn from(f: f64) -> Self {
-        Self::F64(f)
+        Self::Static(StaticNode::F64(f))
     }
 }
 

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -5,9 +5,9 @@
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs
 
 use super::{Object, Value};
-use crate::stry;
 use crate::value::generator::*;
 use crate::value::ValueTrait;
+use crate::{stry, StaticNode};
 use std::io;
 use std::io::Write;
 
@@ -83,13 +83,13 @@ trait Generator: BaseGenerator {
     #[inline(always)]
     fn write_json(&mut self, json: &Value) -> io::Result<()> {
         match *json {
-            Value::Null => self.write(b"null"),
+            Value::Static(StaticNode::Null) => self.write(b"null"),
+            Value::Static(StaticNode::I64(number)) => self.write_int(number),
+            Value::Static(StaticNode::U64(number)) => self.write_uint(number),
+            Value::Static(StaticNode::F64(number)) => self.write_float(number),
+            Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
+            Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
-            Value::I64(number) => self.write_int(number),
-            Value::U64(number) => self.write_uint(number),
-            Value::F64(number) => self.write_float(number),
-            Value::Bool(true) => self.write(b"true"),
-            Value::Bool(false) => self.write(b"false"),
             Value::Array(ref array) => {
                 stry!(self.write_char(b'['));
                 let mut iter = array.iter();
@@ -147,17 +147,18 @@ where
 #[cfg(test)]
 mod test {
     use super::Value;
+    use crate::StaticNode;
     #[test]
     fn null() {
-        assert_eq!(Value::Null.encode(), "null")
+        assert_eq!(Value::Static(StaticNode::Null).encode(), "null")
     }
     #[test]
     fn bool_true() {
-        assert_eq!(Value::Bool(true).encode(), "true")
+        assert_eq!(Value::Static(StaticNode::Bool(true)).encode(), "true")
     }
     #[test]
     fn bool_false() {
-        assert_eq!(Value::Bool(false).encode(), "false")
+        assert_eq!(Value::Static(StaticNode::Bool(false)).encode(), "false")
     }
     fn assert_str(from: &str, to: &str) {
         assert_eq!(Value::String(from.into()).encode(), to)

--- a/src/value/tape.rs
+++ b/src/value/tape.rs
@@ -1,0 +1,84 @@
+/// A tape of a parsed json, all values are extracted and validated and
+/// can be used without further computation.
+use crate::ValueType;
+use float_cmp::approx_eq;
+use std::fmt;
+/// `Tape`
+pub struct Tape<'input>(Vec<Node<'input>>);
+
+/// Tape `Node`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Node<'input> {
+    /// A string, located inside the input slice
+    String(&'input str),
+    /// An `Object` with the given `size` starts here.
+    /// the following values are keys and values, alternating
+    /// however values can be nested and have a length thsemlfs.
+    Object(usize),
+    /// An array with a given size starts here. The next `size`
+    /// elements belong to it - values can be nested and have a
+    /// `size` of their own.
+    Array(usize),
+    /// A static value that is interned into the tape, it can
+    /// be directly taken and isn't nested.
+    Static(StaticNode),
+}
+
+/// Static tape node
+#[derive(Debug, Clone, Copy)]
+pub enum StaticNode {
+    /// A signed integer.
+    I64(i64),
+    /// An unsigned integer.
+    U64(u64),
+    /// A floating point value
+    F64(f64),
+    /// A boolean value
+    Bool(bool),
+    /// The null value
+    Null,
+}
+
+impl StaticNode {
+    /// The type of a static value
+    pub fn value_type(&self) -> ValueType {
+        match self {
+            Self::Null => ValueType::Null,
+            Self::Bool(_) => ValueType::Bool,
+            Self::F64(_) => ValueType::F64,
+            Self::I64(_) => ValueType::I64,
+            Self::U64(_) => ValueType::U64,
+        }
+    }
+}
+
+#[cfg_attr(tarpaulin, skip)]
+impl<'v> fmt::Display for StaticNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Null => write!(f, "null"),
+            Self::Bool(b) => write!(f, "{}", b),
+            Self::I64(n) => write!(f, "{}", n),
+            Self::U64(n) => write!(f, "{}", n),
+            Self::F64(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+#[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
+impl<'a> PartialEq for StaticNode {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Null, Self::Null) => true,
+            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
+            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
+            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
+            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
+            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
+            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
We can move some of the parsing logic into stage 2 instead of checking them after that. This simplifies the code for parse() .

Performance wise it looks like a small improvement too.

![image](https://user-images.githubusercontent.com/119093/67989564-81a33800-fc33-11e9-85f8-0bfda035cc7b.png)


## 0.2
```
======= simd_json ======== parse|stringify ===== parse|stringify ====
data/canada.json         450 MB/s   490 MB/s   630 MB/s   350 MB/s
data/citm_catalog.json  1170 MB/s   600 MB/s  1450 MB/s   760 MB/s
data/twitter.json        950 MB/s   700 MB/s   950 MB/s   750 MB/s
data/log.json           1080 MB/s  2170 MB/s  1080 MB/s  1080 MB/s
```

## this
```
======= simd_json ======== parse|stringify ===== parse|stringify ====
data/canada.json         460 MB/s   490 MB/s   630 MB/s   350 MB/s
data/citm_catalog.json  1120 MB/s   600 MB/s  1450 MB/s   770 MB/s
data/twitter.json        960 MB/s   700 MB/s   970 MB/s   750 MB/s
data/log.json           1080 MB/s  2170 MB/s  1080 MB/s  1080 MB/s
```