### PR TITLE
Try pointers instead of str for strings

### DIFF
--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -18,7 +18,7 @@ impl<'de> Deserializer<'de> {
         input: &'de [u8],
         buffer: &'invoke mut [u8],
         mut idx: usize,
-    ) -> Result<&'de str> {
+    ) -> Result<u32> {
         use ErrorType::*;
         let input: &mut [u8] = unsafe { std::mem::transmute(input) };
         // Add 1 to skip the initial "
@@ -77,10 +77,7 @@ impl<'de> Deserializer<'de> {
                 // we advance the point, accounting for the fact that we have a NULl termination
 
                 len += quote_dist as usize;
-                unsafe {
-                    let v = input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
-                    return Ok(&*v);
-                }
+                return Ok(len as u32);
 
                 // we compare the pointers since we care if they are 'at the same spot'
                 // not if they are the same value
@@ -154,9 +151,7 @@ impl<'de> Deserializer<'de> {
                     input
                         .get_unchecked_mut(idx + len..idx + len + dst_i)
                         .clone_from_slice(&buffer.get_unchecked(..dst_i));
-                    let v =
-                        input.get_unchecked(idx..idx + len + dst_i) as *const [u8] as *const str;
-                    return Ok(&*v);
+                    return Ok((len + dst_i) as u32);
                 }
 
                 // we compare the pointers since we care if they are 'at the same spot'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ mod known_key;
 #[cfg(feature = "known-key")]
 pub use known_key::{Error as KnownKeyError, KnownKey};
 
-pub use crate::tape::{Node, StaticNode, Tape};
+pub use crate::tape::{Node, Tape};
 
 /// Creates a tape from the input for later consumption
 pub fn to_tape<'input>(s: &'input mut [u8]) -> Result<Vec<Node<'input>>> {
@@ -342,7 +342,7 @@ mod tests {
         let v_serde: serde_json::Value = serde_json::from_slice(d).expect("");
         let v_simd: serde_json::Value = from_slice(&mut d).expect("");
         assert_eq!(v_simd, v_serde);
-        assert_eq!(to_value(&mut d1), Ok(Value::Static(StaticNode::Null)));
+        assert_eq!(to_value(&mut d1), Ok(Value::Null));
     }
 
     #[test]
@@ -525,8 +525,8 @@ mod tests {
             to_value(&mut d1),
             Ok(Value::Array(vec![
                 Value::Array(vec![]),
-                Value::Static(StaticNode::Null),
-                Value::Static(StaticNode::Null),
+                Value::Null,
+                Value::Null,
             ]))
         );
         assert_eq!(v_simd, v_serde);
@@ -645,10 +645,7 @@ mod tests {
         assert_eq!(v_simd, v_serde);
         assert_eq!(
             to_value(&mut d1),
-            Ok(Value::Array(vec![
-                Value::from(Object::new()),
-                Value::Static(StaticNode::Null)
-            ]))
+            Ok(Value::Array(vec![Value::from(Object::new()), Value::Null]))
         );
     }
 
@@ -667,7 +664,7 @@ mod tests {
         let mut d1 = d.clone();
         let mut d1 = unsafe { d1.as_bytes_mut() };
         let mut d = unsafe { d.as_bytes_mut() };
-        assert_eq!(to_value(&mut d1), Ok(Value::Static(StaticNode::Null)));
+        assert_eq!(to_value(&mut d1), Ok(Value::Null));
         let v_serde: serde_json::Value = serde_json::from_slice(d).expect("");
         let v_simd: serde_json::Value = from_slice(&mut d).expect("");
         assert_eq!(v_simd, v_serde);
@@ -680,10 +677,7 @@ mod tests {
         let mut d = unsafe { d.as_bytes_mut() };
         assert_eq!(
             to_value(&mut d1),
-            Ok(Value::Array(vec![
-                Value::Static(StaticNode::Null),
-                Value::Static(StaticNode::Null),
-            ]))
+            Ok(Value::Array(vec![Value::Null, Value::Null,]))
         );
         let v_serde: serde_json::Value = serde_json::from_slice(d).expect("");
         let v_simd: serde_json::Value = from_slice(&mut d).expect("");
@@ -699,8 +693,8 @@ mod tests {
         assert_eq!(
             to_value(&mut d1),
             Ok(Value::Array(vec![Value::Array(vec![
-                Value::Static(StaticNode::Null),
-                Value::Static(StaticNode::Null),
+                Value::Null,
+                Value::Null,
             ])]))
         );
 
@@ -721,8 +715,8 @@ mod tests {
         assert_eq!(
             to_value(&mut d1),
             Ok(Value::Array(vec![Value::Array(vec![Value::Array(vec![
-                Value::Static(StaticNode::Null),
-                Value::Static(StaticNode::Null),
+                Value::Null,
+                Value::Null,
             ])])]))
         );
     }
@@ -1059,10 +1053,8 @@ mod tests {
     //6.576692109929364e305
     fn arb_json() -> BoxedStrategy<String> {
         let leaf = prop_oneof![
-            Just(Value::Static(StaticNode::Null)),
-            any::<bool>()
-                .prop_map(StaticNode::Bool)
-                .prop_map(Value::Static),
+            Just(Value::Null),
+            any::<bool>().prop_map(Value::Bool),
             // (-1.0e306f64..1.0e306f64).prop_map(|f| json!(f)), // The float parsing of simd and serde are too different
             any::<i64>().prop_map(|i| json!(i)),
             ".*".prop_map(Value::from),
@@ -1085,10 +1077,8 @@ mod tests {
 
     fn arb_json_value() -> BoxedStrategy<Value> {
         let leaf = prop_oneof![
-            Just(Value::Static(StaticNode::Null)),
-            any::<bool>()
-                .prop_map(StaticNode::Bool)
-                .prop_map(Value::Static),
+            Just(Value::Null),
+            any::<bool>().prop_map(Value::Bool),
             //(-1.0e306f64..1.0e306f64).prop_map(|f| json!(f)), // damn you float!
             any::<i64>().prop_map(|i| json!(i)),
             ".*".prop_map(Value::from),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -264,15 +264,15 @@ macro_rules! json_internal {
     //////////////////////////////////////////////////////////////////////////
 
     (null) => {
-        $crate::value::owned::Value::Static($crate::StaticNode::Null)
+        $crate::value::owned::Value::Null
     };
 
     (true) => {
-        $crate::value::owned::Value::Static($crate::StaticNode::Bool(true))
+        $crate::value::owned::Value::Bool(true)
     };
 
     (false) => {
-        $crate::value::owned::Value::Static($crate::StaticNode::Bool(false))
+        $crate::value::owned::Value::Bool(false)
     };
 
     ([]) => {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -9,9 +9,9 @@
 mod de;
 mod value;
 pub use self::value::*;
+use crate::Node;
 use crate::{stry, Deserializer, Error, ErrorType, Result};
 use crate::{BorrowedValue, OwnedValue};
-use crate::{Node, StaticNode};
 use serde_ext::Deserialize;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -100,8 +100,8 @@ impl<'de> Deserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_signed(&mut self) -> Result<i64> {
         match self.next_() {
-            Node::Static(StaticNode::I64(i)) => Ok(i),
-            Node::Static(StaticNode::U64(n)) => n
+            Node::I64(n) => Ok(n),
+            Node::U64(n) => n
                 .try_into()
                 .map_err(|_| self.error(ErrorType::ExpectedSigned)),
             _ => Err(self.error(ErrorType::ExpectedSigned)),
@@ -112,7 +112,7 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_sign_loss)]
     fn parse_unsigned(&mut self) -> Result<u64> {
         match self.next_() {
-            Node::Static(StaticNode::U64(n)) => Ok(n),
+            Node::U64(n) => Ok(n),
             _ => Err(self.error(ErrorType::ExpectedUnsigned)),
         }
     }
@@ -120,9 +120,9 @@ impl<'de> Deserializer<'de> {
     #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
     fn parse_double(&mut self) -> Result<f64> {
         match self.next_() {
-            Node::Static(StaticNode::F64(n)) => Ok(n),
-            Node::Static(StaticNode::I64(n)) => Ok(n as f64),
-            Node::Static(StaticNode::U64(n)) => Ok(n as f64),
+            Node::F64(n) => Ok(n),
+            Node::I64(n) => Ok(n as f64),
+            Node::U64(n) => Ok(n as f64),
             _ => Err(self.error(ErrorType::ExpectedFloat)),
         }
     }
@@ -133,15 +133,15 @@ impl TryFrom<serde_json::Value> for OwnedValue {
     fn try_from(item: serde_json::Value) -> ConvertResult<Self> {
         use serde_json::Value;
         Ok(match item {
-            Value::Null => Self::Static(StaticNode::Null),
-            Value::Bool(b) => Self::Static(StaticNode::Bool(b)),
+            Value::Null => Self::Null,
+            Value::Bool(b) => Self::Bool(b),
             Value::Number(b) => {
                 if let Some(n) = b.as_i64() {
-                    Self::Static(StaticNode::I64(n))
+                    Self::I64(n)
                 } else if let Some(n) = b.as_u64() {
-                    Self::Static(StaticNode::U64(n))
+                    Self::U64(n)
                 } else if let Some(n) = b.as_f64() {
-                    Self::Static(StaticNode::F64(n))
+                    Self::F64(n)
                 } else {
                     return Err(SerdeConversionError::Oops);
                 }
@@ -164,11 +164,11 @@ impl TryInto<serde_json::Value> for OwnedValue {
     fn try_into(self) -> ConvertResult<serde_json::Value> {
         use serde_json::Value;
         Ok(match self {
-            Self::Static(StaticNode::Null) => Value::Null,
-            Self::Static(StaticNode::Bool(b)) => Value::Bool(b),
-            Self::Static(StaticNode::I64(n)) => Value::Number(n.into()),
-            Self::Static(StaticNode::U64(n)) => Value::Number(n.into()),
-            Self::Static(StaticNode::F64(n)) => {
+            Self::Null => Value::Null,
+            Self::Bool(b) => Value::Bool(b),
+            Self::I64(n) => Value::Number(n.into()),
+            Self::U64(n) => Value::Number(n.into()),
+            Self::F64(n) => {
                 if let Some(n) = serde_json::Number::from_f64(n) {
                     Value::Number(n)
                 } else {
@@ -223,11 +223,11 @@ impl<'value> TryInto<serde_json::Value> for BorrowedValue<'value> {
     fn try_into(self) -> ConvertResult<serde_json::Value> {
         use serde_json::Value;
         Ok(match self {
-            BorrowedValue::Static(StaticNode::Null) => Value::Null,
-            BorrowedValue::Static(StaticNode::Bool(b)) => Value::Bool(b),
-            BorrowedValue::Static(StaticNode::I64(n)) => Value::Number(n.into()),
-            BorrowedValue::Static(StaticNode::U64(n)) => Value::Number(n.into()),
-            BorrowedValue::Static(StaticNode::F64(n)) => {
+            BorrowedValue::Null => Value::Null,
+            BorrowedValue::Bool(b) => Value::Bool(b),
+            BorrowedValue::I64(n) => Value::Number(n.into()),
+            BorrowedValue::U64(n) => Value::Number(n.into()),
+            BorrowedValue::F64(n) => {
                 if let Some(n) = serde_json::Number::from_f64(n) {
                     Value::Number(n)
                 } else {

--- a/src/serde/value/borrowed/de.rs
+++ b/src/serde/value/borrowed/de.rs
@@ -1,6 +1,5 @@
 use crate::value::borrowed::{Object, Value};
 use crate::Error;
-use crate::StaticNode;
 use serde_ext::de::{
     self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor,
 };
@@ -19,11 +18,11 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
         V: Visitor<'de>,
     {
         match self {
-            Value::Static(StaticNode::Null) => visitor.visit_unit(),
-            Value::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
-            Value::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
-            Value::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
-            Value::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
+            Value::Null => visitor.visit_unit(),
+            Value::Bool(b) => visitor.visit_bool(b),
+            Value::I64(n) => visitor.visit_i64(n),
+            Value::U64(n) => visitor.visit_u64(n),
+            Value::F64(n) => visitor.visit_f64(n),
             Value::String(s) => match s {
                 Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
                 Cow::Owned(s) => visitor.visit_string(s),
@@ -31,7 +30,7 @@ impl<'de> de::Deserializer<'de> for Value<'de> {
             Value::Array(a) => visitor.visit_seq(Array(a.iter())),
             Value::Object(o) => visitor.visit_map(ObjectAccess {
                 i: o.iter(),
-                v: &Value::Static(StaticNode::Null),
+                v: &Value::Null,
             }),
         }
     }
@@ -114,19 +113,19 @@ impl<'de> Visitor<'de> for ValueVisitor {
     /****************** unit ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticNode::Null))
+        Ok(Value::Null)
     }
 
     /****************** bool ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticNode::Bool(value)))
+        Ok(Value::Bool(value))
     }
 
     /****************** Option ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticNode::Null))
+        Ok(Value::Null)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -151,7 +150,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(i64::from(value))))
+        Ok(Value::I64(i64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -159,7 +158,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(i64::from(value))))
+        Ok(Value::I64(i64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -167,7 +166,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(i64::from(value))))
+        Ok(Value::I64(i64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -175,7 +174,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(value)))
+        Ok(Value::I64(value))
     }
 
     /****************** u64 ******************/
@@ -185,7 +184,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(u64::from(value))))
+        Ok(Value::U64(u64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -193,7 +192,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(u64::from(value))))
+        Ok(Value::U64(u64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -201,7 +200,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(u64::from(value))))
+        Ok(Value::U64(u64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -209,7 +208,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(value)))
+        Ok(Value::U64(value))
     }
 
     /****************** f64 ******************/
@@ -219,7 +218,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(f64::from(value))))
+        Ok(Value::F64(f64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -227,7 +226,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::F64(value))
     }
 
     /****************** stringy stuff ******************/

--- a/src/serde/value/borrowed/se.rs
+++ b/src/serde/value/borrowed/se.rs
@@ -1,5 +1,4 @@
 use crate::value::borrowed::Value;
-use crate::StaticNode;
 use serde_ext::ser::{
     self, Serialize, SerializeMap as SerializeMapTrait, SerializeSeq as SerializeSeqTrait,
 };
@@ -11,11 +10,11 @@ impl<'a> Serialize for Value<'a> {
         S: ser::Serializer,
     {
         match self {
-            Value::Static(StaticNode::Null) => serializer.serialize_unit(),
-            Value::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
-            Value::Static(StaticNode::F64(f)) => serializer.serialize_f64(*f),
-            Value::Static(StaticNode::I64(i)) => serializer.serialize_i64(*i),
-            Value::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
+            Value::Null => serializer.serialize_unit(),
+            Value::Bool(b) => serializer.serialize_bool(*b),
+            Value::F64(n) => serializer.serialize_f64(*n),
+            Value::I64(n) => serializer.serialize_i64(*n),
+            Value::U64(n) => serializer.serialize_u64(*n),
             Value::String(Cow::Borrowed(s)) => serializer.serialize_str(s),
             Value::String(Cow::Owned(s)) => serializer.serialize_str(&s),
             Value::Array(v) => {

--- a/src/serde/value/owned/de.rs
+++ b/src/serde/value/owned/de.rs
@@ -1,5 +1,4 @@
 use crate::value::owned::{Object, Value};
-use crate::StaticNode;
 use crate::{stry, Error};
 use serde::de::{
     self, Deserialize, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Unexpected, Visitor,
@@ -20,11 +19,11 @@ impl<'de> de::Deserializer<'de> for Value {
         V: Visitor<'de>,
     {
         match self {
-            Self::Static(StaticNode::Null) => visitor.visit_unit(),
-            Self::Static(StaticNode::Bool(b)) => visitor.visit_bool(b),
-            Self::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
-            Self::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
-            Self::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
+            Self::Null => visitor.visit_unit(),
+            Self::Bool(b) => visitor.visit_bool(b),
+            Self::I64(n) => visitor.visit_i64(n),
+            Self::U64(n) => visitor.visit_u64(n),
+            Self::F64(n) => visitor.visit_f64(n),
             Self::String(s) => visitor.visit_string(s),
             Self::Array(a) => visit_array(a, visitor),
             Self::Object(o) => visit_object(o, visitor),
@@ -406,19 +405,19 @@ impl<'de> Visitor<'de> for ValueVisitor {
     /****************** unit ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_unit<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticNode::Null))
+        Ok(Value::Null)
     }
 
     /****************** bool ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticNode::Bool(value)))
+        Ok(Value::Bool(value))
     }
 
     /****************** Option ******************/
     #[cfg_attr(not(feature = "no-inline"), inline)]
     fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(Value::Static(StaticNode::Null))
+        Ok(Value::Null)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -443,7 +442,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(i64::from(value))))
+        Ok(Value::I64(i64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -451,7 +450,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(i64::from(value))))
+        Ok(Value::I64(i64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -459,7 +458,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(i64::from(value))))
+        Ok(Value::I64(i64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -467,7 +466,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::I64(value)))
+        Ok(Value::I64(value))
     }
 
     /****************** u64 ******************/
@@ -477,7 +476,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(u64::from(value))))
+        Ok(Value::U64(u64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -485,7 +484,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(u64::from(value))))
+        Ok(Value::U64(u64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -493,7 +492,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(u64::from(value))))
+        Ok(Value::U64(u64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -501,7 +500,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::U64(value)))
+        Ok(Value::U64(value))
     }
 
     /****************** f64 ******************/
@@ -511,7 +510,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(f64::from(value))))
+        Ok(Value::F64(f64::from(value)))
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
@@ -519,7 +518,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         E: de::Error,
     {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::F64(value))
     }
 
     /****************** stringy stuff ******************/

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -1,6 +1,6 @@
 use super::to_value;
 use crate::value::owned::{Object, Value};
-use crate::{stry, Error, ErrorType, Result, StaticNode};
+use crate::{stry, Error, ErrorType, Result};
 use serde::ser::{self, Serialize};
 use serde_ext::ser::{SerializeMap as SerializeMapTrait, SerializeSeq as SerializeSeqTrait};
 
@@ -12,11 +12,11 @@ impl Serialize for Value {
         S: ser::Serializer,
     {
         match self {
-            Self::Static(StaticNode::Bool(b)) => serializer.serialize_bool(*b),
-            Self::Static(StaticNode::Null) => serializer.serialize_unit(),
-            Self::Static(StaticNode::F64(f)) => serializer.serialize_f64(*f),
-            Self::Static(StaticNode::I64(i)) => serializer.serialize_i64(*i),
-            Self::Static(StaticNode::U64(i)) => serializer.serialize_u64(*i),
+            Self::Bool(b) => serializer.serialize_bool(*b),
+            Self::Null => serializer.serialize_unit(),
+            Self::F64(n) => serializer.serialize_f64(*n),
+            Self::I64(n) => serializer.serialize_i64(*n),
+            Self::U64(n) => serializer.serialize_u64(*n),
             Self::String(s) => serializer.serialize_str(&s),
             Self::Array(v) => {
                 let mut seq = serializer.serialize_seq(Some(v.len()))?;
@@ -57,7 +57,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_bool(self, value: bool) -> Result<Value> {
-        Ok(Value::Static(StaticNode::Bool(value)))
+        Ok(Value::Bool(value))
     }
 
     #[inline]
@@ -76,7 +76,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_i64(self, value: i64) -> Result<Value> {
-        Ok(Value::Static(StaticNode::I64(value)))
+        Ok(Value::I64(value))
     }
 
     #[cfg(feature = "arbitrary_precision")]
@@ -103,8 +103,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<Value> {
-        #[allow(clippy::cast_possible_wrap)]
-        Ok(Value::Static(StaticNode::I64(value as i64)))
+        Ok(Value::U64(value))
     }
 
     #[cfg(feature = "arbitrary_precision")]
@@ -121,7 +120,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_f64(self, value: f64) -> Result<Value> {
-        Ok(Value::Static(StaticNode::F64(value)))
+        Ok(Value::F64(value))
     }
 
     #[inline]
@@ -142,7 +141,7 @@ impl serde::Serializer for Serializer {
 
     #[inline]
     fn serialize_unit(self) -> Result<Value> {
-        Ok(Value::Static(StaticNode::Null))
+        Ok(Value::Null)
     }
 
     #[inline]

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -5,12 +5,13 @@ mod from;
 mod serialize;
 
 use crate::value::{ValueTrait, ValueType};
-use crate::{Deserializer, Node, Result, StaticNode};
+use crate::{Deserializer, Node, Result};
 use halfbrown::HashMap;
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Index, IndexMut};
+use std::{slice, str};
 
 /// Representation of a JSON object
 pub type Object<'v> = HashMap<Cow<'v, str>, Value<'v>>;
@@ -30,8 +31,16 @@ pub fn to_value<'v>(s: &'v mut [u8]) -> Result<Value<'v>> {
 /// to access it's content
 #[derive(Debug, Clone)]
 pub enum Value<'v> {
-    /// Static values
-    Static(StaticNode),
+    /// A signed integer.
+    I64(i64),
+    /// An unsigned integer.
+    U64(u64),
+    /// A floating point value
+    F64(f64),
+    /// A boolean value
+    Bool(bool),
+    /// The null value
+    Null,
     /// string type
     String(Cow<'v, str>),
     /// array type
@@ -71,7 +80,11 @@ impl<'v> Value<'v> {
                     .iter()
                     .map(|(k, v)| (Cow::Owned(k.to_string()), v.clone_static()))
                     .collect(),
-                Self::Static(s) => Self::Static(*s),
+                Self::Null => Self::Null,
+                Self::Bool(b) => Self::Bool(*b),
+                Self::U64(s) => Self::U64(*s),
+                Self::I64(s) => Self::I64(*s),
+                Self::F64(s) => Self::F64(*s),
             })
         }
     }
@@ -90,17 +103,17 @@ impl<'v> ValueTrait for Value<'v> {
     }
     #[inline]
     fn null() -> Self {
-        Self::Static(StaticNode::Null)
+        Self::Null
     }
 
     #[inline]
     fn value_type(&self) -> ValueType {
         match self {
-            Self::Static(StaticNode::Null) => ValueType::Null,
-            Self::Static(StaticNode::Bool(_)) => ValueType::Bool,
-            Self::Static(StaticNode::F64(_)) => ValueType::F64,
-            Self::Static(StaticNode::I64(_)) => ValueType::I64,
-            Self::Static(StaticNode::U64(_)) => ValueType::U64,
+            Self::Null => ValueType::Null,
+            Self::Bool(_) => ValueType::Bool,
+            Self::F64(_) => ValueType::F64,
+            Self::I64(_) => ValueType::I64,
+            Self::U64(_) => ValueType::U64,
             Self::String(_) => ValueType::String,
             Self::Array(_) => ValueType::Array,
             Self::Object(_) => ValueType::Object,
@@ -110,7 +123,7 @@ impl<'v> ValueTrait for Value<'v> {
     #[inline]
     fn is_null(&self) -> bool {
         match self {
-            Self::Static(StaticNode::Null) => true,
+            Self::Null => true,
             _ => false,
         }
     }
@@ -118,7 +131,7 @@ impl<'v> ValueTrait for Value<'v> {
     #[inline]
     fn as_bool(&self) -> Option<bool> {
         match self {
-            Self::Static(StaticNode::Bool(b)) => Some(*b),
+            Self::Bool(b) => Some(*b),
             _ => None,
         }
     }
@@ -126,8 +139,8 @@ impl<'v> ValueTrait for Value<'v> {
     #[inline]
     fn as_i64(&self) -> Option<i64> {
         match self {
-            Self::Static(StaticNode::I64(i)) => Some(*i),
-            Self::Static(StaticNode::U64(i)) => i64::try_from(*i).ok(),
+            Self::I64(n) => Some(*n),
+            Self::U64(n) => i64::try_from(*n).ok(),
             _ => None,
         }
     }
@@ -136,8 +149,8 @@ impl<'v> ValueTrait for Value<'v> {
     fn as_u64(&self) -> Option<u64> {
         #[allow(clippy::cast_sign_loss)]
         match self {
-            Self::Static(StaticNode::I64(i)) => u64::try_from(*i).ok(),
-            Self::Static(StaticNode::U64(i)) => Some(*i),
+            Self::I64(n) => u64::try_from(*n).ok(),
+            Self::U64(n) => Some(*n),
             _ => None,
         }
     }
@@ -145,7 +158,7 @@ impl<'v> ValueTrait for Value<'v> {
     #[inline]
     fn as_f64(&self) -> Option<f64> {
         match self {
-            Self::Static(StaticNode::F64(i)) => Some(*i),
+            Self::F64(n) => Some(*n),
             _ => None,
         }
     }
@@ -154,9 +167,9 @@ impl<'v> ValueTrait for Value<'v> {
     fn cast_f64(&self) -> Option<f64> {
         #[allow(clippy::cast_precision_loss)]
         match self {
-            Self::Static(StaticNode::F64(i)) => Some(*i),
-            Self::Static(StaticNode::I64(i)) => Some(*i as f64),
-            Self::Static(StaticNode::U64(i)) => Some(*i as f64),
+            Self::F64(n) => Some(*n),
+            Self::I64(n) => Some(*n as f64),
+            Self::U64(n) => Some(*n as f64),
             _ => None,
         }
     }
@@ -207,7 +220,11 @@ impl<'v> ValueTrait for Value<'v> {
 impl<'v> fmt::Display for Value<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Static(s) => write!(f, "{}", s),
+            Self::Null => write!(f, "null"),
+            Self::Bool(b) => write!(f, "{}", b),
+            Self::I64(n) => write!(f, "{}", n),
+            Self::U64(n) => write!(f, "{}", n),
+            Self::F64(n) => write!(f, "{}", n),
             Self::String(s) => write!(f, "{}", s),
             Self::Array(a) => write!(f, "{:?}", a),
             Self::Object(o) => write!(f, "{:?}", o),
@@ -243,7 +260,7 @@ impl<'v> IndexMut<usize> for Value<'v> {
 
 impl<'v> Default for Value<'v> {
     fn default() -> Self {
-        Self::Static(StaticNode::Null)
+        Self::Null
     }
 }
 
@@ -257,8 +274,17 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Value<'de> {
         match self.0.next_() {
-            Node::Static(s) => Value::Static(s),
-            Node::String(s) => Value::from(s),
+            Node::Null => Value::Null,
+            Node::Bool(b) => Value::Bool(b),
+            Node::U64(n) => Value::U64(n),
+            Node::I64(n) => Value::I64(n),
+            Node::F64(n) => Value::F64(n),
+            Node::String(len, p, _) => unsafe {
+                Value::from(str::from_utf8_unchecked(slice::from_raw_parts::<'de, u8>(
+                    p,
+                    len as usize,
+                )))
+            },
             Node::Array(len) => self.parse_array(len),
             Node::Object(len) => self.parse_map(len),
         }
@@ -286,8 +312,12 @@ impl<'de> BorrowDeserializer<'de> {
         // Since we checked if it's empty we know that we at least have one
         // element so we eat this
         for _ in 0..len {
-            if let Node::String(key) = self.0.next_() {
-                res.insert_nocheck(key.into(), self.parse());
+            if let Node::String(len, p, _) = self.0.next_() {
+                unsafe {
+                    let key: &'de str =
+                        str::from_utf8_unchecked(slice::from_raw_parts::<'de, u8>(p, len as usize));
+                    res.insert_nocheck(key.into(), self.parse());
+                }
             } else {
                 unreachable!()
             }
@@ -632,19 +662,11 @@ mod test {
     use proptest::prelude::*;
     fn arb_value() -> BoxedStrategy<Value<'static>> {
         let leaf = prop_oneof![
-            Just(Value::Static(StaticNode::Null)),
-            any::<bool>()
-                .prop_map(StaticNode::Bool)
-                .prop_map(Value::Static),
-            any::<i64>()
-                .prop_map(StaticNode::I64)
-                .prop_map(Value::Static),
-            any::<u64>()
-                .prop_map(StaticNode::U64)
-                .prop_map(Value::Static),
-            any::<f64>()
-                .prop_map(StaticNode::F64)
-                .prop_map(Value::Static),
+            Just(Value::Null),
+            any::<bool>().prop_map(Value::from),
+            any::<i64>().prop_map(Value::from),
+            any::<u64>().prop_map(Value::from),
+            any::<f64>().prop_map(Value::from),
             ".*".prop_map(Value::from),
         ];
         leaf.prop_recursive(

--- a/src/value/borrowed/cmp.rs
+++ b/src/value/borrowed/cmp.rs
@@ -1,12 +1,20 @@
 use super::Value;
 use crate::{OwnedValue, ValueTrait};
+use float_cmp::approx_eq;
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl<'a> PartialEq for Value<'a> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Static(s1), Self::Static(s2)) => s1 == s2,
+            (Self::Null, Self::Null) => true,
+            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
+            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
+            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
+            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
+            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
+            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
             (Self::String(v1), Self::String(v2)) => v1.eq(v2),
             (Self::Array(v1), Self::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), Self::Object(v2)) => v1.eq(v2),

--- a/src/value/borrowed/from.rs
+++ b/src/value/borrowed/from.rs
@@ -1,6 +1,5 @@
 use super::{Object, Value};
 use crate::OwnedValue;
-use crate::StaticNode;
 use std::borrow::Cow;
 use std::iter::FromIterator;
 
@@ -8,7 +7,11 @@ impl<'a> From<OwnedValue> for Value<'a> {
     #[inline]
     fn from(b: OwnedValue) -> Self {
         match b {
-            OwnedValue::Static(s) => Value::Static(s),
+            OwnedValue::Null => Value::Null,
+            OwnedValue::Bool(b) => Value::Bool(b),
+            OwnedValue::U64(n) => Value::U64(n),
+            OwnedValue::I64(n) => Value::I64(n),
+            OwnedValue::F64(n) => Value::F64(n),
             OwnedValue::String(s) => Value::from(s.to_string()),
             OwnedValue::Array(a) => a.into_iter().collect(),
             OwnedValue::Object(m) => m.into_iter().collect(),
@@ -42,13 +45,13 @@ impl<'v> From<String> for Value<'v> {
 impl<'v> From<bool> for Value<'v> {
     #[inline]
     fn from(b: bool) -> Self {
-        Value::Static(StaticNode::Bool(b))
+        Value::Bool(b)
     }
 }
 impl<'v> From<()> for Value<'v> {
     #[inline]
     fn from(_b: ()) -> Self {
-        Value::Static(StaticNode::Null)
+        Value::Null
     }
 }
 
@@ -56,28 +59,28 @@ impl<'v> From<()> for Value<'v> {
 impl<'v> From<i8> for Value<'v> {
     #[inline]
     fn from(i: i8) -> Self {
-        Value::Static(StaticNode::I64(i64::from(i)))
+        Value::I64(i64::from(i))
     }
 }
 
 impl<'v> From<i16> for Value<'v> {
     #[inline]
     fn from(i: i16) -> Self {
-        Value::Static(StaticNode::I64(i64::from(i)))
+        Value::I64(i64::from(i))
     }
 }
 
 impl<'v> From<i32> for Value<'v> {
     #[inline]
     fn from(i: i32) -> Self {
-        Value::Static(StaticNode::I64(i64::from(i)))
+        Value::I64(i64::from(i))
     }
 }
 
 impl<'v> From<i64> for Value<'v> {
     #[inline]
     fn from(i: i64) -> Self {
-        Value::Static(StaticNode::I64(i))
+        Value::I64(i)
     }
 }
 
@@ -85,35 +88,35 @@ impl<'v> From<i64> for Value<'v> {
 impl<'v> From<u8> for Value<'v> {
     #[inline]
     fn from(i: u8) -> Self {
-        Self::Static(StaticNode::U64(u64::from(i)))
+        Self::U64(u64::from(i))
     }
 }
 
 impl<'v> From<u16> for Value<'v> {
     #[inline]
     fn from(i: u16) -> Self {
-        Self::Static(StaticNode::U64(u64::from(i)))
+        Self::U64(u64::from(i))
     }
 }
 
 impl<'v> From<u32> for Value<'v> {
     #[inline]
     fn from(i: u32) -> Self {
-        Self::Static(StaticNode::U64(u64::from(i)))
+        Self::U64(u64::from(i))
     }
 }
 
 impl<'v> From<u64> for Value<'v> {
     #[inline]
     fn from(i: u64) -> Self {
-        Value::Static(StaticNode::U64(i))
+        Value::U64(i)
     }
 }
 
 impl<'v> From<usize> for Value<'v> {
     #[inline]
     fn from(i: usize) -> Self {
-        Self::Static(StaticNode::U64(i as u64))
+        Self::U64(i as u64)
     }
 }
 
@@ -121,14 +124,14 @@ impl<'v> From<usize> for Value<'v> {
 impl<'v> From<f32> for Value<'v> {
     #[inline]
     fn from(f: f32) -> Self {
-        Value::Static(StaticNode::F64(f64::from(f)))
+        Value::F64(f64::from(f))
     }
 }
 
 impl<'v> From<f64> for Value<'v> {
     #[inline]
     fn from(f: f64) -> Self {
-        Value::Static(StaticNode::F64(f))
+        Value::F64(f)
     }
 }
 

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -8,7 +8,6 @@ use super::{Object, Value};
 use crate::stry;
 use crate::value::generator::*;
 use crate::value::ValueTrait;
-use crate::StaticNode;
 use std::io;
 use std::io::Write;
 
@@ -84,12 +83,12 @@ trait Generator: BaseGenerator {
     #[inline(always)]
     fn write_json(&mut self, json: &Value) -> io::Result<()> {
         match *json {
-            Value::Static(StaticNode::Null) => self.write(b"null"),
-            Value::Static(StaticNode::I64(number)) => self.write_int(number),
-            Value::Static(StaticNode::U64(number)) => self.write_uint(number),
-            Value::Static(StaticNode::F64(number)) => self.write_float(number),
-            Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
-            Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
+            Value::Null => self.write(b"null"),
+            Value::I64(number) => self.write_int(number),
+            Value::U64(number) => self.write_uint(number),
+            Value::F64(number) => self.write_float(number),
+            Value::Bool(true) => self.write(b"true"),
+            Value::Bool(false) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
             Value::Array(ref array) => {
                 stry!(self.write_char(b'['));
@@ -148,18 +147,17 @@ where
 #[cfg(test)]
 mod test {
     use super::Value;
-    use crate::StaticNode;
     #[test]
     fn null() {
-        assert_eq!(Value::Static(StaticNode::Null).encode(), "null")
+        assert_eq!(Value::Null.encode(), "null")
     }
     #[test]
     fn bool_true() {
-        assert_eq!(Value::Static(StaticNode::Bool(true)).encode(), "true")
+        assert_eq!(Value::Bool(true).encode(), "true")
     }
     #[test]
     fn bool_false() {
-        assert_eq!(Value::Static(StaticNode::Bool(false)).encode(), "false")
+        assert_eq!(Value::Bool(false).encode(), "false")
     }
     fn assert_str(from: &str, to: &str) {
         assert_eq!(Value::String(from.into()).encode(), to)

--- a/src/value/owned/cmp.rs
+++ b/src/value/owned/cmp.rs
@@ -1,12 +1,20 @@
 use super::Value;
 use crate::{BorrowedValue, ValueTrait};
+use float_cmp::approx_eq;
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl PartialEq<BorrowedValue<'_>> for Value {
     #[inline]
     fn eq(&self, other: &BorrowedValue<'_>) -> bool {
         match (self, other) {
-            (Self::Static(s1), BorrowedValue::Static(s2)) => s1 == s2,
+            (Self::Null, BorrowedValue::Null) => true,
+            (Self::Bool(v1), BorrowedValue::Bool(v2)) => v1.eq(v2),
+            (Self::I64(v1), BorrowedValue::I64(v2)) => v1.eq(v2),
+            (Self::F64(v1), BorrowedValue::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            (Self::U64(v1), BorrowedValue::U64(v2)) => v1.eq(v2),
+            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
+            (Self::U64(v1), BorrowedValue::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
+            (Self::I64(v1), BorrowedValue::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
             (Self::String(v1), BorrowedValue::String(v2)) => v1.eq(v2),
             (Self::Array(v1), BorrowedValue::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), BorrowedValue::Object(v2)) => {
@@ -26,7 +34,14 @@ impl PartialEq for Value {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Static(s1), Self::Static(s2)) => s1.eq(s2),
+            (Self::Null, Self::Null) => true,
+            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
+            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
+            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
+            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
+            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
+            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
+            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
             (Self::String(v1), Self::String(v2)) => v1.eq(v2),
             (Self::Array(v1), Self::Array(v2)) => v1.eq(v2),
             (Self::Object(v1), Self::Object(v2)) => v1.eq(v2),

--- a/src/value/owned/from.rs
+++ b/src/value/owned/from.rs
@@ -1,5 +1,5 @@
 use super::{Object, Value};
-use crate::{BorrowedValue, StaticNode};
+use crate::BorrowedValue;
 use std::borrow::Cow;
 use std::iter::FromIterator;
 
@@ -7,7 +7,11 @@ impl From<crate::BorrowedValue<'_>> for Value {
     #[inline]
     fn from(b: BorrowedValue<'_>) -> Self {
         match b {
-            BorrowedValue::Static(s) => Self::Static(s),
+            BorrowedValue::Null => Value::Null,
+            BorrowedValue::Bool(b) => Value::Bool(b),
+            BorrowedValue::U64(n) => Value::U64(n),
+            BorrowedValue::I64(n) => Value::I64(n),
+            BorrowedValue::F64(n) => Value::F64(n),
             BorrowedValue::String(s) => Self::from(s.to_string()),
             BorrowedValue::Array(a) => a.into_iter().collect(),
             BorrowedValue::Object(m) => m.into_iter().collect(),
@@ -50,14 +54,14 @@ impl From<&String> for Value {
 impl From<bool> for Value {
     #[inline]
     fn from(b: bool) -> Self {
-        Self::Static(StaticNode::Bool(b))
+        Self::Bool(b)
     }
 }
 
 impl From<()> for Value {
     #[inline]
     fn from(_b: ()) -> Self {
-        Self::Static(StaticNode::Null)
+        Self::Null
     }
 }
 
@@ -65,28 +69,28 @@ impl From<()> for Value {
 impl From<i8> for Value {
     #[inline]
     fn from(i: i8) -> Self {
-        Self::Static(StaticNode::I64(i64::from(i)))
+        Self::I64(i64::from(i))
     }
 }
 
 impl From<i16> for Value {
     #[inline]
     fn from(i: i16) -> Self {
-        Self::Static(StaticNode::I64(i64::from(i)))
+        Self::I64(i64::from(i))
     }
 }
 
 impl From<i32> for Value {
     #[inline]
     fn from(i: i32) -> Self {
-        Self::Static(StaticNode::I64(i64::from(i)))
+        Self::I64(i64::from(i))
     }
 }
 
 impl From<i64> for Value {
     #[inline]
     fn from(i: i64) -> Self {
-        Self::Static(StaticNode::I64(i))
+        Self::I64(i)
     }
 }
 
@@ -94,21 +98,21 @@ impl From<i64> for Value {
 impl From<u8> for Value {
     #[inline]
     fn from(i: u8) -> Self {
-        Self::Static(StaticNode::U64(u64::from(i)))
+        Self::U64(u64::from(i))
     }
 }
 
 impl From<u16> for Value {
     #[inline]
     fn from(i: u16) -> Self {
-        Self::Static(StaticNode::U64(u64::from(i)))
+        Self::U64(u64::from(i))
     }
 }
 
 impl From<u32> for Value {
     #[inline]
     fn from(i: u32) -> Self {
-        Self::Static(StaticNode::U64(u64::from(i)))
+        Self::U64(u64::from(i))
     }
 }
 
@@ -116,14 +120,14 @@ impl From<u64> for Value {
     #[inline]
     fn from(i: u64) -> Self {
         #[allow(clippy::cast_possible_wrap)]
-        Self::Static(StaticNode::U64(i))
+        Self::U64(i)
     }
 }
 
 impl From<usize> for Value {
     #[inline]
     fn from(i: usize) -> Self {
-        Self::Static(StaticNode::U64(i as u64))
+        Self::U64(i as u64)
     }
 }
 
@@ -131,14 +135,14 @@ impl From<usize> for Value {
 impl From<f32> for Value {
     #[inline]
     fn from(f: f32) -> Self {
-        Self::Static(StaticNode::F64(f64::from(f)))
+        Self::F64(f64::from(f))
     }
 }
 
 impl From<f64> for Value {
     #[inline]
     fn from(f: f64) -> Self {
-        Self::Static(StaticNode::F64(f))
+        Self::F64(f)
     }
 }
 

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -5,9 +5,9 @@
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs
 
 use super::{Object, Value};
+use crate::stry;
 use crate::value::generator::*;
 use crate::value::ValueTrait;
-use crate::{stry, StaticNode};
 use std::io;
 use std::io::Write;
 
@@ -83,12 +83,12 @@ trait Generator: BaseGenerator {
     #[inline(always)]
     fn write_json(&mut self, json: &Value) -> io::Result<()> {
         match *json {
-            Value::Static(StaticNode::Null) => self.write(b"null"),
-            Value::Static(StaticNode::I64(number)) => self.write_int(number),
-            Value::Static(StaticNode::U64(number)) => self.write_uint(number),
-            Value::Static(StaticNode::F64(number)) => self.write_float(number),
-            Value::Static(StaticNode::Bool(true)) => self.write(b"true"),
-            Value::Static(StaticNode::Bool(false)) => self.write(b"false"),
+            Value::Null => self.write(b"null"),
+            Value::I64(number) => self.write_int(number),
+            Value::U64(number) => self.write_uint(number),
+            Value::F64(number) => self.write_float(number),
+            Value::Bool(true) => self.write(b"true"),
+            Value::Bool(false) => self.write(b"false"),
             Value::String(ref string) => self.write_string(string),
             Value::Array(ref array) => {
                 stry!(self.write_char(b'['));
@@ -147,18 +147,17 @@ where
 #[cfg(test)]
 mod test {
     use super::Value;
-    use crate::StaticNode;
     #[test]
     fn null() {
-        assert_eq!(Value::Static(StaticNode::Null).encode(), "null")
+        assert_eq!(Value::Null.encode(), "null")
     }
     #[test]
     fn bool_true() {
-        assert_eq!(Value::Static(StaticNode::Bool(true)).encode(), "true")
+        assert_eq!(Value::Bool(true).encode(), "true")
     }
     #[test]
     fn bool_false() {
-        assert_eq!(Value::Static(StaticNode::Bool(false)).encode(), "false")
+        assert_eq!(Value::Bool(false).encode(), "false")
     }
     fn assert_str(from: &str, to: &str) {
         assert_eq!(Value::String(from.into()).encode(), to)

--- a/src/value/tape.rs
+++ b/src/value/tape.rs
@@ -1,8 +1,7 @@
 /// A tape of a parsed json, all values are extracted and validated and
 /// can be used without further computation.
-use crate::ValueType;
-use float_cmp::approx_eq;
-use std::fmt;
+use std::marker::PhantomData;
+
 /// `Tape`
 pub struct Tape<'input>(Vec<Node<'input>>);
 
@@ -10,7 +9,7 @@ pub struct Tape<'input>(Vec<Node<'input>>);
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Node<'input> {
     /// A string, located inside the input slice
-    String(&'input str),
+    String(u32, *const u8, PhantomData<&'input [u8]>),
     /// An `Object` with the given `size` starts here.
     /// the following values are keys and values, alternating
     /// however values can be nested and have a length thsemlfs.
@@ -19,14 +18,6 @@ pub enum Node<'input> {
     /// elements belong to it - values can be nested and have a
     /// `size` of their own.
     Array(usize),
-    /// A static value that is interned into the tape, it can
-    /// be directly taken and isn't nested.
-    Static(StaticNode),
-}
-
-/// Static tape node
-#[derive(Debug, Clone, Copy)]
-pub enum StaticNode {
     /// A signed integer.
     I64(i64),
     /// An unsigned integer.
@@ -37,48 +28,4 @@ pub enum StaticNode {
     Bool(bool),
     /// The null value
     Null,
-}
-
-impl StaticNode {
-    /// The type of a static value
-    pub fn value_type(&self) -> ValueType {
-        match self {
-            Self::Null => ValueType::Null,
-            Self::Bool(_) => ValueType::Bool,
-            Self::F64(_) => ValueType::F64,
-            Self::I64(_) => ValueType::I64,
-            Self::U64(_) => ValueType::U64,
-        }
-    }
-}
-
-#[cfg_attr(tarpaulin, skip)]
-impl<'v> fmt::Display for StaticNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Null => write!(f, "null"),
-            Self::Bool(b) => write!(f, "{}", b),
-            Self::I64(n) => write!(f, "{}", n),
-            Self::U64(n) => write!(f, "{}", n),
-            Self::F64(n) => write!(f, "{}", n),
-        }
-    }
-}
-
-#[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
-impl<'a> PartialEq for StaticNode {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Null, Self::Null) => true,
-            (Self::Bool(v1), Self::Bool(v2)) => v1.eq(v2),
-            (Self::I64(v1), Self::I64(v2)) => v1.eq(v2),
-            (Self::F64(v1), Self::F64(v2)) => approx_eq!(f64, *v1, *v2),
-            (Self::U64(v1), Self::U64(v2)) => v1.eq(v2),
-            // NOTE: We swap v1 and v2 here to avoid having to juggle ref's
-            (Self::U64(v1), Self::I64(v2)) if *v2 >= 0 => (*v2 as u64).eq(v1),
-            (Self::I64(v1), Self::U64(v2)) if *v1 >= 0 => (*v1 as u64).eq(v2),
-            _ => false,
-        }
-    }
 }


### PR DESCRIPTION
This PR would use a pointer and 32bit length instead of a &str on the tape - that way the size of an tape node is reduced to 16 byte and string creation is handled after the fact.

Turns out despite the space savings this is degrading performance - I'll open and close this PR for tracking purposes.