### PR TITLE
Encode object end for nested tape nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ mod tests {
         let mut d = String::from("[]");
         let mut d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(&mut d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(0));
+        assert_eq!(simd.tape[1], Node::Array(0, 2));
     }
 
     #[test]
@@ -268,7 +268,7 @@ mod tests {
         let mut d = String::from("[1]");
         let mut d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(&mut d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(1));
+        assert_eq!(simd.tape[1], Node::Array(1, 3));
     }
 
     #[test]
@@ -276,7 +276,7 @@ mod tests {
         let mut d = String::from("[1,2]");
         let mut d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(&mut d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(2));
+        assert_eq!(simd.tape[1], Node::Array(2, 4));
     }
 
     #[test]
@@ -284,8 +284,8 @@ mod tests {
         let mut d = String::from(" [ 1 , [ 3 ] , 2 ]");
         let mut d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(&mut d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(3));
-        assert_eq!(simd.tape[3], Node::Array(1));
+        assert_eq!(simd.tape[1], Node::Array(3, 6));
+        assert_eq!(simd.tape[3], Node::Array(1, 5));
     }
 
     #[test]
@@ -293,8 +293,8 @@ mod tests {
         let mut d = String::from("[[],null,null]");
         let mut d = unsafe { d.as_bytes_mut() };
         let simd = Deserializer::from_slice(&mut d).expect("");
-        assert_eq!(simd.tape[1], Node::Array(3));
-        assert_eq!(simd.tape[2], Node::Array(0));
+        assert_eq!(simd.tape[1], Node::Array(3, 5));
+        assert_eq!(simd.tape[2], Node::Array(0, 3));
     }
 
     #[test]

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -23,8 +23,8 @@ where
             Node::Static(StaticNode::F64(n)) => visitor.visit_f64(n),
             Node::Static(StaticNode::I64(n)) => visitor.visit_i64(n),
             Node::Static(StaticNode::U64(n)) => visitor.visit_u64(n),
-            Node::Array(len) => visitor.visit_seq(CommaSeparated::new(&mut self, len as usize)),
-            Node::Object(len) => visitor.visit_map(CommaSeparated::new(&mut self, len as usize)),
+            Node::Array(len, _) => visitor.visit_seq(CommaSeparated::new(&mut self, len as usize)),
+            Node::Object(len, _) => visitor.visit_map(CommaSeparated::new(&mut self, len as usize)),
         }
     }
 
@@ -218,7 +218,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Node::Array(len)) = self.next() {
+        if let Ok(Node::Array(len, _)) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_seq(CommaSeparated::new(&mut self, len as usize))
         } else {
@@ -281,7 +281,7 @@ where
         V: Visitor<'de>,
     {
         // Parse the opening bracket of the sequence.
-        if let Ok(Node::Object(len)) = self.next() {
+        if let Ok(Node::Object(len, _)) = self.next() {
             // Give the visitor access to each element of the sequence.
             visitor.visit_map(CommaSeparated::new(&mut self, len as usize))
         } else {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -323,7 +323,7 @@ impl<'de> Deserializer<'de> {
                 *get_mut!(stack, depth) = (StackState::Start, last_start, cnt);
 
                 last_start = r_i;
-                insert_res!(Node::Object(0));
+                insert_res!(Node::Object(0, 0));
 
                 depth += 1;
                 cnt = 1;
@@ -347,7 +347,7 @@ impl<'de> Deserializer<'de> {
                 *get_mut!(stack, depth) = (StackState::Start, last_start, cnt);
 
                 last_start = r_i;
-                insert_res!(Node::Array(0));
+                insert_res!(Node::Array(0, 0));
 
                 depth += 1;
                 cnt = 1;
@@ -511,7 +511,7 @@ impl<'de> Deserializer<'de> {
                                     (StackState::Object, last_start, cnt);
                             }
                             last_start = r_i;
-                            insert_res!(Node::Object(0));
+                            insert_res!(Node::Object(0, 0));
                             depth += 1;
                             cnt = 1;
                             object_begin!();
@@ -522,7 +522,7 @@ impl<'de> Deserializer<'de> {
                                     (StackState::Object, last_start, cnt);
                             }
                             last_start = r_i;
-                            insert_res!(Node::Array(0));
+                            insert_res!(Node::Array(0, 0));
                             depth += 1;
                             cnt = 1;
                             array_begin!();
@@ -540,7 +540,11 @@ impl<'de> Deserializer<'de> {
                     depth -= 1;
                     unsafe {
                         match res.get_unchecked_mut(last_start) {
-                            Node::Array(ref mut len) | Node::Object(ref mut len) => *len = cnt,
+                            Node::Array(ref mut len, ref mut end)
+                            | Node::Object(ref mut len, ref mut end) => {
+                                *len = cnt;
+                                *end = r_i;
+                            }
                             _ => unreachable!(),
                         };
                     }
@@ -617,7 +621,7 @@ impl<'de> Deserializer<'de> {
                                     (StackState::Array, last_start, cnt);
                             }
                             last_start = r_i;
-                            insert_res!(Node::Object(0));
+                            insert_res!(Node::Object(0, 0));
                             depth += 1;
                             cnt = 1;
                             object_begin!();
@@ -628,7 +632,7 @@ impl<'de> Deserializer<'de> {
                                     (StackState::Array, last_start, cnt);
                             }
                             last_start = r_i;
-                            insert_res!(Node::Array(0));
+                            insert_res!(Node::Array(0, 0));
                             depth += 1;
                             cnt = 1;
                             array_begin!();

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -259,8 +259,8 @@ impl<'de> BorrowDeserializer<'de> {
         match self.0.next_() {
             Node::Static(s) => Value::Static(s),
             Node::String(s) => Value::from(s),
-            Node::Array(len) => self.parse_array(len),
-            Node::Object(len) => self.parse_map(len),
+            Node::Array(len, _) => self.parse_array(len),
+            Node::Object(len, _) => self.parse_map(len),
         }
     }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -220,8 +220,8 @@ impl<'de> OwnedDeserializer<'de> {
         match self.de.next_() {
             Node::Static(s) => Value::Static(s),
             Node::String(s) => Value::from(s),
-            Node::Array(len) => self.parse_array(len),
-            Node::Object(len) => self.parse_map(len),
+            Node::Array(len, _) => self.parse_array(len),
+            Node::Object(len, _) => self.parse_map(len),
         }
     }
 

--- a/src/value/tape.rs
+++ b/src/value/tape.rs
@@ -14,11 +14,11 @@ pub enum Node<'input> {
     /// An `Object` with the given `size` starts here.
     /// the following values are keys and values, alternating
     /// however values can be nested and have a length thsemlfs.
-    Object(usize),
+    Object(usize, usize),
     /// An array with a given size starts here. The next `size`
     /// elements belong to it - values can be nested and have a
     /// `size` of their own.
-    Array(usize),
+    Array(usize, usize),
     /// A static value that is interned into the tape, it can
     /// be directly taken and isn't nested.
     Static(StaticNode),


### PR DESCRIPTION
Storing the end node allow skipping entire nested note if we need to while looking over it.

bench to be done