### PR TITLE
Split traits into read, mutate and build

### DIFF
--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -11,7 +11,12 @@ use crate::Deserializer;
 pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::if_not_else, mutable_transmutes, clippy::transmute_ptr_to_ptr)]
+    #[allow(
+        clippy::if_not_else,
+        mutable_transmutes,
+        clippy::transmute_ptr_to_ptr,
+        clippy::too_many_lines
+    )]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],

--- a/src/avx2/deser.rs
+++ b/src/avx2/deser.rs
@@ -18,10 +18,11 @@ impl<'de> Deserializer<'de> {
         clippy::too_many_lines,
         clippy::cast_ptr_alignment,
         clippy::cast_possible_wrap,
-        clippy::if_not_else
+        clippy::if_not_else,
+        clippy::too_many_lines
     )]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_<'invoke>(
+    pub(crate) fn parse_str_<'invoke>(
         input: &'de [u8],
         buffer: &'invoke mut [u8],
         mut idx: usize,

--- a/src/avx2/generator.rs
+++ b/src/avx2/generator.rs
@@ -7,7 +7,7 @@ use crate::value::generator::ESCAPED;
 use std::io;
 
 #[inline(always)]
-pub unsafe fn write_str_simd<W>(
+pub(crate) unsafe fn write_str_simd<W>(
     writer: &mut W,
     string: &mut &[u8],
     len: &mut usize,

--- a/src/avx2/generator.rs
+++ b/src/avx2/generator.rs
@@ -7,6 +7,7 @@ use crate::value::generator::ESCAPED;
 use std::io;
 
 #[inline(always)]
+#[allow(clippy::cast_possible_wrap, clippy::cast_ptr_alignment)]
 pub(crate) unsafe fn write_str_simd<W>(
     writer: &mut W,
     string: &mut &[u8],
@@ -18,13 +19,10 @@ where
 {
     let zero = _mm256_set1_epi8(0);
     let lower_quote_range = _mm256_set1_epi8(0x1F as i8);
-    #[allow(clippy::cast_possible_wrap)]
     let quote = _mm256_set1_epi8(b'"' as i8);
-    #[allow(clippy::cast_possible_wrap)]
     let backslash = _mm256_set1_epi8(b'\\' as i8);
     while *len - *idx >= 32 {
         // Load 32 bytes of data;
-        #[allow(clippy::cast_ptr_alignment)]
         let data: __m256i = _mm256_loadu_si256(string.as_ptr().add(*idx) as *const __m256i);
         // Test the data against being backslash and quote.
         let bs_or_quote = _mm256_or_si256(

--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -1,4 +1,4 @@
-use crate::{ValueTrait, ValueType};
+use crate::{MutableValue, Value as ValueTrait, ValueType};
 use halfbrown::RawEntryMut;
 use std::borrow::{Borrow, Cow};
 use std::fmt;
@@ -96,8 +96,8 @@ impl<'key> KnownKey<'key> {
     where
         'key: 'value,
         'value: 'borrow,
-        V: ValueTrait + 'value,
-        V::Key: Hash + Eq + Borrow<str>,
+        V: MutableValue + 'value,
+        <V as MutableValue>::Key: Hash + Eq + Borrow<str>,
     {
         target.as_object_mut().and_then(|m| {
             match m
@@ -147,8 +147,8 @@ impl<'key> KnownKey<'key> {
     where
         'key: 'value,
         'value: 'borrow,
-        V: ValueTrait + 'value,
-        V::Key: Hash + Eq + Borrow<str> + From<Cow<'key, str>>,
+        V: ValueTrait + MutableValue + 'value,
+        <V as MutableValue>::Key: Hash + Eq + Borrow<str> + From<Cow<'key, str>>,
         F: FnOnce() -> V,
     {
         if !target.is_object() {
@@ -198,8 +198,8 @@ impl<'key> KnownKey<'key> {
     where
         'key: 'value,
         'value: 'borrow,
-        V: ValueTrait + 'value,
-        V::Key: Hash + Eq + Borrow<str> + From<Cow<'key, str>>,
+        V: MutableValue + 'value,
+        <V as MutableValue>::Key: Hash + Eq + Borrow<str> + From<Cow<'key, str>>,
     {
         if !target.is_object() {
             return Err(Error::NotAnObject(target.value_type()));
@@ -225,7 +225,7 @@ mod tests {
     #![allow(clippy::unnecessary_operation, clippy::non_ascii_literal)]
     use super::*;
     use crate::borrowed::*;
-    use crate::{BorrowedValue, ValueTrait};
+    use crate::{BorrowedValue, Value as ValueTrait, ValueBuilder};
 
     #[test]
     fn known_key() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,8 @@ mod tests {
     #![allow(clippy::unnecessary_operation, clippy::non_ascii_literal)]
     use super::serde::from_slice;
     use super::{
-        owned::to_value, owned::Object, owned::Value, to_borrowed_value, to_owned_value,
-        Deserializer,
+        deserialize, owned::to_value, owned::Object, owned::Value, to_borrowed_value,
+        to_owned_value, BorrowedValue, Deserializer, OwnedValue,
     };
     use crate::tape::*;
     use halfbrown::HashMap;
@@ -1122,7 +1122,17 @@ mod tests {
             let mut encoded: Vec<u8> = Vec::new();
             let _ = val.write(&mut encoded);
             println!("{}", String::from_utf8_lossy(&encoded.clone()));
-            let res = to_owned_value(&mut encoded).expect("can't convert");
+            let mut e = encoded.clone();
+            let res = to_owned_value(&mut e).expect("can't convert");
+            assert_eq!(val, res);
+            let mut e = encoded.clone();
+            let res = to_borrowed_value(&mut e).expect("can't convert");
+            assert_eq!(val, res);
+            let mut e = encoded.clone();
+            let res: OwnedValue = deserialize(&mut e).expect("can't convert");
+            assert_eq!(val, res);
+            let mut e = encoded.clone();
+            let res: BorrowedValue = deserialize(&mut e).expect("can't convert");
             assert_eq!(val, res);
         }
 

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -12,10 +12,11 @@ impl<'de> Deserializer<'de> {
         clippy::transmute_ptr_to_ptr,
         clippy::cast_ptr_alignment,
         clippy::if_not_else,
-        clippy::cast_ptr_alignment
+        clippy::cast_ptr_alignment,
+        clippy::too_many_lines
     )]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_<'invoke>(
+    pub(crate) fn parse_str_<'invoke>(
         input: &'de [u8],
         buffer: &'invoke mut [u8],
         mut idx: usize,

--- a/src/neon/deser.rs
+++ b/src/neon/deser.rs
@@ -6,7 +6,14 @@ use crate::Result;
 use simd_lite::aarch64::*;
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::if_not_else, mutable_transmutes, clippy::transmute_ptr_to_ptr)]
+    #[allow(
+        clippy::if_not_else,
+        mutable_transmutes,
+        clippy::transmute_ptr_to_ptr,
+        clippy::cast_ptr_alignment,
+        clippy::if_not_else,
+        clippy::cast_ptr_alignment
+    )]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],
@@ -30,7 +37,6 @@ impl<'de> Deserializer<'de> {
         loop {
             let (v0, v1) = if src.len() >= src_i + 32 {
                 // This is safe since we ensure src is at least 16 wide
-                #[allow(clippy::cast_ptr_alignment)]
                 unsafe {
                     (
                         vld1q_u8(src.get_unchecked(src_i..src_i + 16).as_ptr()),
@@ -91,11 +97,9 @@ impl<'de> Deserializer<'de> {
         let mut dst_i: usize = 0;
 
         // To be more conform with upstream
-        #[allow(clippy::if_not_else)]
         loop {
             let (v0, v1) = if src.len() >= src_i + 32 {
                 // This is safe since we ensure src is at least 16 wide
-                #[allow(clippy::cast_ptr_alignment)]
                 unsafe {
                     (
                         vld1q_u8(src.get_unchecked(src_i..src_i + 16).as_ptr()),

--- a/src/neon/generator.rs
+++ b/src/neon/generator.rs
@@ -4,7 +4,7 @@ use simd_lite::aarch64::*;
 use std::io;
 
 #[inline(always)]
-pub unsafe fn write_str_simd<W>(
+pub(crate) unsafe fn write_str_simd<W>(
     writer: &mut W,
     string: &mut &[u8],
     len: &mut usize,

--- a/src/neon/stage1.rs
+++ b/src/neon/stage1.rs
@@ -85,9 +85,9 @@ struct SimdInput {
     v3: uint8x16_t,
 }
 
+#[allow(clippy::cast_ptr_alignment)]
 fn fill_input(ptr: &[u8]) -> SimdInput {
     unsafe {
-        #[allow(clippy::cast_ptr_alignment)]
         SimdInput {
             v0: vld1q_u8(ptr.as_ptr() as *const u8),
             v1: vld1q_u8(ptr.as_ptr().add(16) as *const u8),
@@ -341,6 +341,7 @@ unsafe fn find_whitespace_and_structurals(
 // needs to be large enough to handle this
 //TODO: usize was u32 here does this matter?
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
+#[allow(clippy::cast_ptr_alignment)]
 fn flatten_bits(base: &mut Vec<u32>, idx: u32, mut bits: u64) {
     let cnt: usize = bits.count_ones() as usize;
     let mut l = base.len();
@@ -377,7 +378,6 @@ fn flatten_bits(base: &mut Vec<u32>, idx: u32, mut bits: u64) {
 
             let v: int32x4_t = mem::transmute([v0, v1, v2, v3]);
             let v: int32x4_t = vaddq_s32(idx_64_v, v);
-            #[allow(clippy::cast_ptr_alignment)]
             std::ptr::write(base.as_mut_ptr().add(l) as *mut int32x4_t, v);
         }
         l += 4;

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -170,7 +170,8 @@ impl<'de> Deserializer<'de> {
     #[allow(
         clippy::cast_sign_loss,
         clippy::cast_possible_wrap,
-        clippy::cast_precision_loss
+        clippy::cast_precision_loss,
+        clippy::too_many_lines
     )]
     fn parse_float(idx: usize, p: &[u8], negative: bool) -> Result<StaticNode> {
         let mut digitcount = if negative { 1 } else { 0 };
@@ -381,9 +382,10 @@ impl<'de> Deserializer<'de> {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         clippy::cast_precision_loss,
-        clippy::cast_possible_wrap
+        clippy::cast_possible_wrap,
+        clippy::too_many_lines
     )]
-    pub fn parse_number_int(idx: usize, buf: &[u8], negative: bool) -> Result<StaticNode> {
+    pub(crate) fn parse_number_int(idx: usize, buf: &[u8], negative: bool) -> Result<StaticNode> {
         let mut byte_count = if negative { 1 } else { 0 };
         let mut ignore_count: u8 = 0;
         //let startdigits: *const u8 = p;

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -101,9 +101,9 @@ fn is_not_structural_or_whitespace_or_exponent_or_decimal(c: u8) -> bool {
 // http://0x80.pl/articles/swar-digits-validate.html
 
 #[cfg_attr(not(feature = "no-inline"), inline)]
+#[allow(clippy::cast_ptr_alignment)]
 fn is_made_of_eight_digits_fast(chars: &[u8]) -> bool {
     // We know what we're doing right? :P
-    #[allow(clippy::cast_ptr_alignment)]
     let val: u64 = unsafe { *(chars.as_ptr() as *const u64) };
 
     //    let val: __m64 = *(chars as *const __m64);

--- a/src/numberparse.rs
+++ b/src/numberparse.rs
@@ -579,7 +579,7 @@ impl<'de> Deserializer<'de> {
 mod test {
     #![allow(clippy::default_trait_access)]
     use crate::value::owned::to_value;
-    use crate::value::ValueTrait;
+    use crate::value::Value as ValueTrait;
     use float_cmp::approx_eq;
 
     #[test]

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -82,32 +82,32 @@ where
     // The `parse_signed` function is generic over the integer type `T` so here
     // it is invoked with `T=i8`. The next 8 methods are similar.
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: i64 = stry!(self.parse_signed());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_i8(v as i8)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: i64 = stry!(self.parse_signed());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_i16(v as i16)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: i64 = stry!(self.parse_signed());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_i32(v as i32)
     }
 
@@ -120,32 +120,32 @@ where
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: u64 = stry!(self.parse_unsigned());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_u8(v as u8)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: u64 = stry!(self.parse_unsigned());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_u16(v as u16)
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: u64 = stry!(self.parse_unsigned());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_u32(v as u32)
     }
 
@@ -158,12 +158,12 @@ where
     }
 
     #[cfg_attr(not(feature = "no-inline"), inline)]
+    #[allow(clippy::cast_possible_truncation)]
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         let v: f64 = stry!(self.parse_double());
-        #[allow(clippy::cast_possible_truncation)]
         visitor.visit_f32(v as f32)
     }
 

--- a/src/serde/value/owned/se.rs
+++ b/src/serde/value/owned/se.rs
@@ -102,8 +102,8 @@ impl serde::Serializer for Serializer {
     }
 
     #[inline]
+    #[allow(clippy::cast_possible_wrap)]
     fn serialize_u64(self, value: u64) -> Result<Value> {
-        #[allow(clippy::cast_possible_wrap)]
         Ok(Value::Static(StaticNode::I64(value as i64)))
     }
 

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -11,7 +11,13 @@ use crate::Deserializer;
 pub use crate::Result;
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::if_not_else, mutable_transmutes, clippy::transmute_ptr_to_ptr)]
+    #[allow(
+        clippy::if_not_else,
+        mutable_transmutes,
+        clippy::transmute_ptr_to_ptr,
+        clippy::cast_ptr_alignment,
+        clippy::cast_possible_wrap
+    )]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse_str_<'invoke>(
         input: &'de [u8],
@@ -35,17 +41,13 @@ impl<'de> Deserializer<'de> {
         loop {
             let v: __m128i = if src.len() >= src_i + 16 {
                 // This is safe since we ensure src is at least 16 wide
-                #[allow(clippy::cast_ptr_alignment)]
-                unsafe {
-                    _mm_loadu_si128(src.as_ptr().add(src_i) as *const __m128i)
-                }
+                unsafe { _mm_loadu_si128(src.as_ptr().add(src_i) as *const __m128i) }
             } else {
                 unsafe {
                     padding
                         .get_unchecked_mut(..src.len() - src_i)
                         .clone_from_slice(src.get_unchecked(src_i..));
                     // This is safe since we ensure src is at least 32 wide
-                    #[allow(clippy::cast_ptr_alignment)]
                     _mm_loadu_si128(padding.as_ptr() as *const __m128i)
                 }
             };
@@ -55,11 +57,9 @@ impl<'de> Deserializer<'de> {
             let bs_bits: u32 = unsafe {
                 static_cast_u32!(_mm_movemask_epi8(_mm_cmpeq_epi8(
                     v,
-                    #[allow(clippy::cast_possible_wrap)]
                     _mm_set1_epi8(b'\\' as i8)
                 )))
             };
-            #[allow(clippy::cast_possible_wrap)]
             let quote_mask = unsafe { _mm_cmpeq_epi8(v, _mm_set1_epi8(b'"' as i8)) };
             let quote_bits = unsafe { static_cast_u32!(_mm_movemask_epi8(quote_mask)) };
             if (bs_bits.wrapping_sub(1) & quote_bits) != 0 {
@@ -101,40 +101,30 @@ impl<'de> Deserializer<'de> {
         let mut dst_i: usize = 0;
 
         // To be more conform with upstream
-        #[allow(clippy::if_not_else)]
         loop {
             let v: __m128i = if src.len() >= src_i + 16 {
                 // This is safe since we ensure src is at least 16 wide
-                #[allow(clippy::cast_ptr_alignment)]
-                unsafe {
-                    _mm_loadu_si128(src.as_ptr().add(src_i) as *const __m128i)
-                }
+                unsafe { _mm_loadu_si128(src.as_ptr().add(src_i) as *const __m128i) }
             } else {
                 unsafe {
                     padding
                         .get_unchecked_mut(..src.len() - src_i)
                         .clone_from_slice(src.get_unchecked(src_i..));
                     // This is safe since we ensure src is at least 16 wide
-                    #[allow(clippy::cast_ptr_alignment)]
                     _mm_loadu_si128(padding.as_ptr() as *const __m128i)
                 }
             };
 
-            #[allow(clippy::cast_ptr_alignment)]
-            unsafe {
-                _mm_storeu_si128(buffer.as_mut_ptr().add(dst_i) as *mut __m128i, v)
-            };
+            unsafe { _mm_storeu_si128(buffer.as_mut_ptr().add(dst_i) as *mut __m128i, v) };
 
             // store to dest unconditionally - we can overwrite the bits we don't like
             // later
             let bs_bits: u32 = unsafe {
                 static_cast_u32!(_mm_movemask_epi8(_mm_cmpeq_epi8(
                     v,
-                    #[allow(clippy::cast_possible_wrap)]
                     _mm_set1_epi8(b'\\' as i8)
                 )))
             };
-            #[allow(clippy::cast_possible_wrap)]
             let quote_mask = unsafe { _mm_cmpeq_epi8(v, _mm_set1_epi8(b'"' as i8)) };
             let quote_bits = unsafe { static_cast_u32!(_mm_movemask_epi8(quote_mask)) };
             if (bs_bits.wrapping_sub(1) & quote_bits) != 0 {

--- a/src/sse42/deser.rs
+++ b/src/sse42/deser.rs
@@ -16,10 +16,11 @@ impl<'de> Deserializer<'de> {
         mutable_transmutes,
         clippy::transmute_ptr_to_ptr,
         clippy::cast_ptr_alignment,
-        clippy::cast_possible_wrap
+        clippy::cast_possible_wrap,
+        clippy::too_many_lines
     )]
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    pub fn parse_str_<'invoke>(
+    pub(crate) fn parse_str_<'invoke>(
         input: &'de [u8],
         buffer: &'invoke mut [u8],
         mut idx: usize,

--- a/src/sse42/generator.rs
+++ b/src/sse42/generator.rs
@@ -7,7 +7,8 @@ use crate::value::generator::ESCAPED;
 use std::io;
 
 #[inline(always)]
-pub unsafe fn write_str_simd<W>(
+#[allow(clippy::cast_possible_wrap, clippy::cast_ptr_alignment)]
+pub(crate) unsafe fn write_str_simd<W>(
     writer: &mut W,
     string: &mut &[u8],
     len: &mut usize,
@@ -18,13 +19,10 @@ where
 {
     let zero = _mm_set1_epi8(0);
     let lower_quote_range = _mm_set1_epi8(0x1F as i8);
-    #[allow(clippy::cast_possible_wrap)]
     let quote = _mm_set1_epi8(b'"' as i8);
-    #[allow(clippy::cast_possible_wrap)]
     let backslash = _mm_set1_epi8(b'\\' as i8);
     while *len - *idx > 16 {
         // Load 16 bytes of data;
-        #[allow(clippy::cast_ptr_alignment)]
         let data: __m128i = _mm_loadu_si128(string.as_ptr().add(*idx) as *const __m128i);
         // Test the data against being backslash and quote.
         let bs_or_quote =

--- a/src/sse42/stage1.rs
+++ b/src/sse42/stage1.rs
@@ -18,9 +18,9 @@ struct SimdInput {
     v3: __m128i,
 }
 
+#[allow(clippy::cast_ptr_alignment)]
 fn fill_input(ptr: &[u8]) -> SimdInput {
     unsafe {
-        #[allow(clippy::cast_ptr_alignment)]
         SimdInput {
             v0: _mm_loadu_si128(ptr.as_ptr() as *const __m128i),
             v1: _mm_loadu_si128(ptr.as_ptr().add(16) as *const __m128i),
@@ -67,8 +67,8 @@ unsafe fn check_utf8(input: &SimdInput, has_error: &mut __m128i, previous: &mut 
 /// a straightforward comparison of a mask against input. 5 uops; would be
 /// cheaper in AVX512.
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 fn cmp_mask_against_input(input: &SimdInput, m: u8) -> u64 {
-    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     unsafe {
         let mask: __m128i = _mm_set1_epi8(m as i8);
         let cmp_res_0: __m128i = _mm_cmpeq_epi8(input.v0, mask);
@@ -85,8 +85,8 @@ fn cmp_mask_against_input(input: &SimdInput, m: u8) -> u64 {
 
 // find all values less than or equal than the content of maxval (using unsigned arithmetic)
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
+#[allow(clippy::cast_sign_loss)]
 fn unsigned_lteq_against_input(input: &SimdInput, maxval: __m128i) -> u64 {
-    #[allow(clippy::cast_sign_loss)]
     unsafe {
         let cmp_res_0: __m128i = _mm_cmpeq_epi8(_mm_max_epu8(maxval, input.v0), maxval);
         let res_0: u64 = u64::from(static_cast_u32!(_mm_movemask_epi8(cmp_res_0)));
@@ -152,6 +152,7 @@ fn find_odd_backslash_sequences(input: &SimdInput, prev_iter_ends_odd_backslash:
 // sequences outside quotes; these
 // backslash sequences (of any length) will be detected elsewhere.
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
+#[allow(overflowing_literals, clippy::cast_sign_loss)]
 unsafe fn find_quote_mask_and_bits(
     input: &SimdInput,
     odd_ends: u64,
@@ -162,7 +163,6 @@ unsafe fn find_quote_mask_and_bits(
     *quote_bits = cmp_mask_against_input(&input, b'"');
     *quote_bits &= !odd_ends;
     // remove from the valid quoted region the unescapted characters.
-    #[allow(overflowing_literals, clippy::cast_sign_loss)]
     let mut quote_mask: u64 = _mm_cvtsi128_si64(_mm_clmulepi64_si128(
         _mm_set_epi64x(0, static_cast_i64!(*quote_bits)),
         _mm_set1_epi8(0xFF),
@@ -303,6 +303,7 @@ unsafe fn find_whitespace_and_structurals(
 // needs to be large enough to handle this
 //TODO: usize was u32 here does this matter?
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
+#[allow(clippy::cast_possible_wrap, clippy::cast_ptr_alignment)]
 fn flatten_bits(base: &mut Vec<u32>, idx: u32, mut bits: u64) {
     let cnt: usize = bits.count_ones() as usize;
     let mut l = base.len();
@@ -327,7 +328,6 @@ fn flatten_bits(base: &mut Vec<u32>, idx: u32, mut bits: u64) {
     }
 
     while bits != 0 {
-        #[allow(clippy::cast_possible_wrap)]
         unsafe {
             let v0 = bits.trailing_zeros() as i32;
             bits &= bits.wrapping_sub(1);
@@ -340,7 +340,6 @@ fn flatten_bits(base: &mut Vec<u32>, idx: u32, mut bits: u64) {
 
             let v: __m128i = _mm_set_epi32(v3, v2, v1, v0);
             let v: __m128i = _mm_add_epi32(idx_64_v, v);
-            #[allow(clippy::cast_ptr_alignment)]
             _mm_storeu_si128(base.as_mut_ptr().add(l) as *mut __m128i, v);
         }
         l += 4;

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -124,8 +124,11 @@ enum StackState {
 }
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::cognitive_complexity)]
-    pub fn build_tape(input: &'de mut [u8], structural_indexes: &[u32]) -> Result<Vec<Node<'de>>> {
+    #[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
+    pub(crate) fn build_tape(
+        input: &'de mut [u8],
+        structural_indexes: &[u32],
+    ) -> Result<Vec<Node<'de>>> {
         // While a valid json can have at max len/2 (`[[[]]]`)elements that are relevant
         // a invalid json might exceed this `[[[[[[` and we need to pretect against that.
         let mut res: Vec<Node<'de>> = Vec::with_capacity(structural_indexes.len());

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -43,10 +43,7 @@ macro_rules! get {
 #[cfg(not(feature = "safe"))]
 macro_rules! get {
     ($a:expr, $i:expr) => {{
-        #[allow(unused_unsafe)]
-        unsafe {
-            $a.get_unchecked($i)
-        }
+        unsafe { $a.get_unchecked($i) }
     }};
 }
 
@@ -60,15 +57,12 @@ macro_rules! get_mut {
 #[cfg(not(feature = "safe"))]
 macro_rules! get_mut {
     ($a:expr, $i:expr) => {{
-        #[allow(unused_unsafe)]
-        unsafe {
-            $a.get_unchecked_mut($i)
-        }
+        unsafe { $a.get_unchecked_mut($i) }
     }};
 }
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
-#[allow(clippy::cast_ptr_alignment)]
+#[allow(clippy::cast_ptr_alignment, unused_unsafe)]
 pub fn is_valid_false_atom(loc: &[u8]) -> bool {
     // TODO: this is ugly and probably copies data every time
     let mut error: u64;
@@ -93,7 +87,7 @@ pub fn is_valid_false_atom(loc: &[u8]) -> bool {
 }
 
 #[cfg_attr(not(feature = "no-inline"), inline(always))]
-#[allow(clippy::cast_ptr_alignment)]
+#[allow(clippy::cast_ptr_alignment, unused_unsafe)]
 pub fn is_valid_null_atom(loc: &[u8]) -> bool {
     // TODO is this expensive?
     let mut error: u64;
@@ -124,7 +118,7 @@ enum StackState {
 }
 
 impl<'de> Deserializer<'de> {
-    #[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
+    #[allow(clippy::cognitive_complexity, clippy::too_many_lines, unused_unsafe)]
     pub(crate) fn build_tape(
         input: &'de mut [u8],
         structural_indexes: &[u32],
@@ -163,7 +157,6 @@ impl<'de> Deserializer<'de> {
                         // We need to ensure that rust doens't
                         // try to free strings that we never
                         // allocated
-                        #[allow(unused_unsafe)]
                         unsafe {
                             res.set_len(r_i);
                         };
@@ -301,7 +294,6 @@ impl<'de> Deserializer<'de> {
                 // We need to ensure that rust doens't
                 // try to free strings that we never
                 // allocated
-                #[allow(unused_unsafe)]
                 unsafe {
                     res.set_len(r_i);
                 };
@@ -311,7 +303,6 @@ impl<'de> Deserializer<'de> {
                 // We need to ensure that rust doens't
                 // try to free strings that we never
                 // allocated
-                #[allow(unused_unsafe)]
                 unsafe {
                     res.set_len(r_i);
                 };

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,7 +17,7 @@
 ///
 /// Objects can be treated as hashmap's for the most part
 /// ```rust
-/// use simd_json::{OwnedValue as Value, ValueTrait};
+/// use simd_json::{OwnedValue as Value, Value as ValueTrait, ValueBuilder, MutableValue};
 /// let mut v = Value::object();
 /// v.insert("key", 42);
 /// assert_eq!(v.get("key").unwrap(), &42);
@@ -29,7 +29,7 @@
 /// Arrays can be treated as vectors for the most part
 ///
 /// ```rust
-/// use simd_json::{OwnedValue as Value, ValueTrait};
+/// use simd_json::{OwnedValue as Value, Value as ValueTrait, ValueBuilder, MutableValue};
 /// let mut v = Value::array();
 /// v.push("zero");
 /// v.push(1);
@@ -42,7 +42,7 @@
 ///
 /// Nested changes are also possible:
 /// ```rust
-/// use simd_json::{OwnedValue as Value, ValueTrait};
+/// use simd_json::{OwnedValue as Value, Value as ValueTrait, ValueBuilder, MutableValue};
 /// let mut o = Value::object();
 /// o.insert("key", Value::array());
 /// o["key"].push(Value::object());

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -79,16 +79,14 @@ impl<'v> Value<'v> {
 
 impl<'v> ValueBuilder for Value<'v> {
     #[inline]
-    fn array() -> Self {
-        Self::Array(Vec::new())
-    }
-    #[inline]
-    fn object() -> Self {
-        Self::Object(Box::new(Object::new()))
-    }
-    #[inline]
     fn null() -> Self {
         Self::Static(StaticNode::Null)
+    }
+    fn array_with_capacity(capacity: usize) -> Self {
+        Self::Array(Vec::with_capacity(capacity))
+    }
+    fn object_with_capacity(capacity: usize) -> Self {
+        Self::Object(Box::new(Object::with_capacity(capacity)))
     }
 }
 

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -147,8 +147,8 @@ impl<'v> ValueTrait for Value<'v> {
     }
 
     #[inline]
+    #[allow(clippy::cast_sign_loss)]
     fn as_u64(&self) -> Option<u64> {
-        #[allow(clippy::cast_sign_loss)]
         match self {
             Self::Static(StaticNode::I64(i)) => u64::try_from(*i).ok(),
             Self::Static(StaticNode::U64(i)) => Some(*i),
@@ -165,8 +165,8 @@ impl<'v> ValueTrait for Value<'v> {
     }
 
     #[inline]
+    #[allow(clippy::cast_precision_loss)]
     fn cast_f64(&self) -> Option<f64> {
-        #[allow(clippy::cast_precision_loss)]
         match self {
             Self::Static(StaticNode::F64(i)) => Some(*i),
             Self::Static(StaticNode::I64(i)) => Some(*i as f64),
@@ -690,16 +690,16 @@ mod test {
             prop_assert_eq!(borrowed, decoded)
         }
         #[test]
+        #[allow(clippy::float_cmp)]
         fn prop_f64_cmp(f in proptest::num::f64::NORMAL) {
-            #[allow(clippy::float_cmp)]
             let v: Value = f.into();
             prop_assert_eq!(v, f)
 
         }
 
         #[test]
+        #[allow(clippy::float_cmp)]
         fn prop_f32_cmp(f in proptest::num::f32::NORMAL) {
-            #[allow(clippy::float_cmp)]
             let v: Value = f.into();
             prop_assert_eq!(v, f)
 
@@ -730,8 +730,8 @@ mod test {
             prop_assert_eq!(v, f)
         }
 
-        #[allow(clippy::cast_possible_truncation)]
         #[test]
+        #[allow(clippy::cast_possible_truncation)]
         fn prop_usize_cmp(f in proptest::num::usize::ANY) {
             let v: Value = f.into();
             prop_assert_eq!(v, f)

--- a/src/value/borrowed/cmp.rs
+++ b/src/value/borrowed/cmp.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use crate::{OwnedValue, ValueTrait};
+use crate::{OwnedValue, Value as ValueTrait};
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl<'a> PartialEq for Value<'a> {

--- a/src/value/borrowed/from.rs
+++ b/src/value/borrowed/from.rs
@@ -16,6 +16,12 @@ impl<'a> From<OwnedValue> for Value<'a> {
     }
 }
 
+impl<'v> From<StaticNode> for Value<'v> {
+    #[inline]
+    fn from(s: StaticNode) -> Self {
+        Self::Static(s)
+    }
+}
 /********* str_ **********/
 impl<'v> From<&'v str> for Value<'v> {
     #[inline]

--- a/src/value/borrowed/serialize.rs
+++ b/src/value/borrowed/serialize.rs
@@ -7,7 +7,7 @@
 use super::{Object, Value};
 use crate::stry;
 use crate::value::generator::*;
-use crate::value::ValueTrait;
+use crate::value::Value as ValueTrait;
 use crate::StaticNode;
 use std::io;
 use std::io::Write;

--- a/src/value/generator.rs
+++ b/src/value/generator.rs
@@ -4,7 +4,7 @@
 //
 // https://github.com/maciejhirsz/json-rust/blob/master/src/codegen.rs
 
-use crate::value::ValueTrait;
+use crate::value::Value as ValueTrait;
 use std::io;
 use std::io::Write;
 use std::marker::PhantomData;

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -44,16 +44,14 @@ pub enum Value {
 
 impl ValueBuilder for Value {
     #[inline]
-    fn array() -> Self {
-        Self::Array(Vec::new())
-    }
-    #[inline]
-    fn object() -> Self {
-        Self::Object(Box::new(Object::new()))
-    }
-    #[inline]
     fn null() -> Self {
         Self::Static(StaticNode::Null)
+    }
+    fn array_with_capacity(capacity: usize) -> Self {
+        Self::Array(Vec::with_capacity(capacity))
+    }
+    fn object_with_capacity(capacity: usize) -> Self {
+        Self::Object(Box::new(Object::with_capacity(capacity)))
     }
 }
 

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -112,8 +112,8 @@ impl ValueTrait for Value {
     }
 
     #[inline]
+    #[allow(clippy::cast_sign_loss)]
     fn as_u64(&self) -> Option<u64> {
-        #[allow(clippy::cast_sign_loss)]
         match self {
             Self::Static(StaticNode::I64(i)) => u64::try_from(*i).ok(),
             Self::Static(StaticNode::U64(i)) => Some(*i),
@@ -130,8 +130,8 @@ impl ValueTrait for Value {
     }
 
     #[inline]
+    #[allow(clippy::cast_precision_loss)]
     fn cast_f64(&self) -> Option<f64> {
-        #[allow(clippy::cast_precision_loss)]
         match self {
             Self::Static(StaticNode::F64(i)) => Some(*i),
             Self::Static(StaticNode::I64(i)) => Some(*i as f64),
@@ -642,16 +642,16 @@ mod test {
             prop_assert_eq!(owned, decoded)
         }
         #[test]
+        #[allow(clippy::float_cmp)]
         fn prop_f64_cmp(f in proptest::num::f64::NORMAL) {
-            #[allow(clippy::float_cmp)]
             let v: Value = f.into();
             prop_assert_eq!(v, f)
 
         }
 
         #[test]
+        #[allow(clippy::float_cmp)]
         fn prop_f32_cmp(f in proptest::num::f32::NORMAL) {
-            #[allow(clippy::float_cmp)]
             let v: Value = f.into();
             prop_assert_eq!(v, f)
 
@@ -682,8 +682,8 @@ mod test {
             prop_assert_eq!(v, f)
         }
 
-        #[allow(clippy::cast_possible_truncation)]
         #[test]
+        #[allow(clippy::cast_possible_truncation)]
         fn prop_usize_cmp(f in proptest::num::usize::ANY) {
             let v: Value = f.into();
             prop_assert_eq!(v, f)

--- a/src/value/owned/cmp.rs
+++ b/src/value/owned/cmp.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use crate::{BorrowedValue, ValueTrait};
+use crate::{BorrowedValue, Value as ValueTrait};
 
 #[allow(clippy::cast_sign_loss, clippy::default_trait_access)]
 impl PartialEq<BorrowedValue<'_>> for Value {

--- a/src/value/owned/from.rs
+++ b/src/value/owned/from.rs
@@ -15,6 +15,12 @@ impl From<crate::BorrowedValue<'_>> for Value {
     }
 }
 
+impl From<StaticNode> for Value {
+    #[inline]
+    fn from(s: StaticNode) -> Self {
+        Self::Static(s)
+    }
+}
 /********* str_ **********/
 
 impl From<&str> for Value {

--- a/src/value/owned/from.rs
+++ b/src/value/owned/from.rs
@@ -120,8 +120,8 @@ impl From<u32> for Value {
 
 impl From<u64> for Value {
     #[inline]
+    #[allow(clippy::cast_possible_wrap)]
     fn from(i: u64) -> Self {
-        #[allow(clippy::cast_possible_wrap)]
         Self::Static(StaticNode::U64(i))
     }
 }

--- a/src/value/owned/serialize.rs
+++ b/src/value/owned/serialize.rs
@@ -6,7 +6,7 @@
 
 use super::{Object, Value};
 use crate::value::generator::*;
-use crate::value::ValueTrait;
+use crate::value::Value as ValueTrait;
 use crate::{stry, StaticNode};
 use std::io;
 use std::io::Write;


### PR DESCRIPTION
This is a pure API change and should have no performance impact. The goal here is to split out different aspects for the value trait to allow implementing only parts of it. Since 0.2 is a declared breaking API it feels like the right time to do.

This will allow us to do things like make non mutable Value variants that have better performance or even serialise directly to objects.