### PR TITLE
Switch to not compiling with a non SIMD capable cpu settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ swar-number-parsing = []
 serde_impl = [ "serde", "serde_json", "halfbrown/serde" ]
 # Support for ARM NEON SIMD
 neon = ["simd-lite"]
+# Allow fallback to non simd CPUs
+allow-non-simd = []
 # for testing allocations
 alloc = ["alloc_counter"]
 # don't inline code - used for debugging

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To be able to take advantage of simdjson your system needs to be SIMD compatible
 
 simd-json.rs supports AVX2, SSE4.2 and NEON.
 
+Unless the `allow-non-simd` feature is passed simd-json will fail to compile, this is to prevent unexpected slowness in fallback mode that can be hard to understand.
+
 ### allocator
 
 For best performance we highly suggest using [mimalloc](https://crates.io/crates/mimalloc) or [jemalloc](https://crates.io/crates/jemalloc) instead of the system allocator used by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,11 +160,11 @@ pub use crate::avx2::deser::*;
 #[cfg(target_feature = "avx2")]
 use crate::avx2::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
 
-#[cfg(all(target_feature = "sse42", not(target_feature = "avx2")))]
+#[cfg(all(target_feature = "sse4.2", not(target_feature = "avx2")))]
 mod sse42;
-#[cfg(all(target_feature = "sse42", not(target_feature = "avx2")))]
+#[cfg(all(target_feature = "sse4.2", not(target_feature = "avx2")))]
 pub use crate::sse42::deser::*;
-#[cfg(all(target_feature = "sse42", not(target_feature = "avx2")))]
+#[cfg(all(target_feature = "sse4.2", not(target_feature = "avx2")))]
 use crate::sse42::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
 
 #[cfg(all(target_feature = "neon", feature = "neon"))]
@@ -176,24 +176,24 @@ use crate::neon::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
 
 // We import this as generics
 #[cfg(all(not(any(
-    target_feature = "sse42",
+    target_feature = "sse4.2",
     target_feature = "avx2",
     target_feature = "neon"
 ))))]
 mod sse42;
 #[cfg(all(not(any(
-    target_feature = "sse42",
+    target_feature = "sse4.2",
     target_feature = "avx2",
     target_feature = "neon"
 ))))]
 #[cfg(all(not(any(
-    target_feature = "sse42",
+    target_feature = "sse4.2",
     target_feature = "avx2",
     target_feature = "neon"
 ))))]
 pub use crate::sse42::deser::*;
 #[cfg(all(not(any(
-    target_feature = "sse42",
+    target_feature = "sse4.2",
     target_feature = "avx2",
     target_feature = "neon"
 ))))]
@@ -202,7 +202,7 @@ use crate::sse42::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
 #[cfg(all(
     not(feature = "allow-non-simd"),
     not(any(
-        target_feature = "sse42",
+        target_feature = "sse4.2",
         target_feature = "avx2",
         target_feature = "neon"
     ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,20 +160,11 @@ pub use crate::avx2::deser::*;
 #[cfg(target_feature = "avx2")]
 use crate::avx2::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
 
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(target_feature = "avx2")
-))]
+#[cfg(all(target_feature = "sse42", not(target_feature = "avx2")))]
 mod sse42;
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(target_feature = "avx2")
-))]
+#[cfg(all(target_feature = "sse42", not(target_feature = "avx2")))]
 pub use crate::sse42::deser::*;
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    not(target_feature = "avx2")
-))]
+#[cfg(all(target_feature = "sse42", not(target_feature = "avx2")))]
 use crate::sse42::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
 
 #[cfg(all(target_feature = "neon", feature = "neon"))]
@@ -182,6 +173,41 @@ mod neon;
 pub use crate::neon::deser::*;
 #[cfg(all(target_feature = "neon", feature = "neon"))]
 use crate::neon::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
+
+// We import this as generics
+#[cfg(all(not(any(
+    target_feature = "sse42",
+    target_feature = "avx2",
+    target_feature = "neon"
+))))]
+mod sse42;
+#[cfg(all(not(any(
+    target_feature = "sse42",
+    target_feature = "avx2",
+    target_feature = "neon"
+))))]
+#[cfg(all(not(any(
+    target_feature = "sse42",
+    target_feature = "avx2",
+    target_feature = "neon"
+))))]
+pub use crate::sse42::deser::*;
+#[cfg(all(not(any(
+    target_feature = "sse42",
+    target_feature = "avx2",
+    target_feature = "neon"
+))))]
+use crate::sse42::stage1::{SimdInput, SIMDINPUT_LENGTH, SIMDJSON_PADDING};
+
+#[cfg(all(
+    not(feature = "allow-non-simd"),
+    not(any(
+        target_feature = "sse42",
+        target_feature = "avx2",
+        target_feature = "neon"
+    ))
+))]
+fn please_compile_with_a_simd_compatible_cpu_setting_read_the_simdjonsrs_readme() -> ! {}
 
 use crate::utf8check::ProcessedUtfBytes;
 


### PR DESCRIPTION
#101 shows that allowing fallback is a tricky beast. It leads to users having a bad experience, that shouldn't happen while not compiling is annoying having a slow system for non-obvious reason from a library that is about speed is worse. 

This PR disables it and creates an error when compiled w/o see42, avx2 or NEON.  It can be re-enabled with the `allow-non-simd` flag.

solves #34 