### PR TITLE
Add KnownKey.key() for when lookup() is insufficient ( presence vs nullity)

### DIFF
--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -328,4 +328,14 @@ mod tests {
         assert_eq!(v["key"], 2);
         assert_eq!(v["cake"], 3);
     }
+
+    #[test]
+    fn known_key_get_key() {
+        use std::borrow::Cow;
+        let mut o = Object::with_capacity(128);
+        o.insert("snot".into(), 1.into());
+        let key1 = KnownKey::from(Cow::Borrowed("snot"));
+
+        assert_eq!(key1.key(), "snot");
+    }
 }

--- a/src/known_key.rs
+++ b/src/known_key.rs
@@ -46,6 +46,12 @@ where
 }
 
 impl<'key> KnownKey<'key> {
+    /// The known key
+    #[inline]
+    pub fn key(&self) -> &Cow<'key, str> {
+        &self.key
+    }
+
     /// Looks up this key in a `Value`, returns None if the
     /// key wasn't present or `target` isn't an object
     ///


### PR DESCRIPTION
Add KnownKey.key() for when lookup() is insufficient ( presence vs nullity)