### PR TITLE
Io error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simd-json"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Heinz N. Gies <heinz@licenser.net>", "Sunny Gleason"]
 edition = "2018"
 exclude = [ "data/*" ]

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg_attr(tarpaulin, skip)]
 impl From<Error> for std::io::Error {
     fn from(e: Error) -> Self {
         std::io::Error::new(std::io::ErrorKind::InvalidData, e)

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,12 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<Error> for std::io::Error {
+    fn from(e: Error) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, e)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -172,7 +172,7 @@ impl fmt::Display for Error {
 
 impl From<Error> for std::io::Error {
     fn from(e: Error) -> Self {
-        std::io::Error::new(std::io::ErrorKind::Other, e)
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,9 @@ extern crate serde as serde_ext;
 /// serde related helper functions
 pub mod serde;
 
+#[cfg(feature = "serde_impl")]
+pub use crate::serde::{from_reader, from_slice, from_str};
+
 /// Default trait imports;
 pub mod prelude;
 


### PR DESCRIPTION
Add conversion to `io::Error` for convenient use of errors and pull serde functions to the top level if serde is used.